### PR TITLE
Apply template settings to Pandoc builds and expand regulatory handover docs

### DIFF
--- a/slides/README.md
+++ b/slides/README.md
@@ -148,9 +148,46 @@ Yes. Export charts as SVG or PNG and reference them in Markdown. When KEB conver
 - Every render writes `metadata.json` summarizing authorship, revision, sensitivity, slide count, link status, and template checksum.
 - (Planned) A future `--freeze` flag will embed a SHA256 of the template and Markdown source into the deck notes so reviewers can verify provenance offline.
 
+## Regulatory gatekeeper context (CE/ISO validation)
+
+For regulated deliveries, the review body validating datasets and verification evidence is often an accredited conformity assessment organization rather than the software contractor itself.
+
+- **BSI (British Standards Institution)**: standards body and certification provider active in ISO-aligned management system certification.
+- **TÜV organizations (e.g., TÜV SÜD, TÜV Rheinland)**: independent testing/inspection/certification bodies frequently used for technical files, safety cases, and process audits.
+- **Belgium context**: Belgian projects commonly use a notified body or accredited auditor selected by the prime contractor; subcontracted assessment by TÜV SÜD (or equivalent) is possible when contractually delegated.
+
+### Corrigendum note (parked for next release)
+
+- **CORR-REG-0001 (planned)**: The contractor **shall** ensure that any subcontracted gatekeeper (including TÜV entities) abides by the governing CE/ISO code item once the exact clause identifier is finalized in the contract annex.
+
+## Delivery depth, intent, and handover checklist
+
+Use this checklist to capture the total structure/gist of each deck-build change set and support clean handover:
+
+1. **Content depth**
+   - Source manifests included (`slides/src/**`), with revision labels.
+   - Evidence references and hyperlink inventories recorded in metadata.
+2. **Style depth**
+   - Template lineage tracked (`template_path`, checksum, theme colors).
+   - Partner-branding options documented (`--partner-logo`, `--base-url`).
+3. **Structure depth**
+   - Output parity across PPTX/PDF/HTML confirmed from one source.
+   - Layout alias mapping validated for any custom slide masters.
+4. **Intent and outcome**
+   - Business objective and target audience recorded in deck metadata/frontmatter.
+   - Governance report reviewed for required fields before release.
+5. **Versioning and cross-references**
+   - Tag metadata revision (`DECK_REVISION`) to match release identifier.
+   - Link DOW run ID, artifact bundle path, and PR number in release notes.
+
+### TODO (next steps)
+
+- Finalize the contractual CE/ISO clause code and replace `CORR-REG-0001` placeholder.
+- Add a CI check that fails if regulatory handover fields are missing from metadata.
+- Extend changelog entries to include contractor/notified-body assignment per release.
+
 ## Change log
 
 - **2025-02-17**: Added multi-format parity guidance, hyperlink preservation, and DOW/KEB integration examples.
 - **2025-02-10**: Documented template customization and batch building workflows.
 - **2025-02-03**: Documented metadata reporting for GBOGEB governance checks.
-

--- a/slides/README.md
+++ b/slides/README.md
@@ -166,10 +166,10 @@ Use this checklist to capture the total structure/gist of each deck-build change
 
 1. **Content depth**
    - Source manifests included (`slides/src/**`), with revision labels.
-   - Evidence references and hyperlink inventories recorded in metadata.
+   - Evidence references and hyperlink inventories documented for handover; automated metadata capture is planned and should not be assumed in current `build_deck()` output.
 2. **Style depth**
    - Template lineage tracked (`template_path`, checksum, theme colors).
-   - Partner-branding options documented (`--partner-logo`, `--base-url`).
+   - Partner-branding options documented in build notes and/or metadata when used (`--partner-logo`, `--base-url`).
 3. **Structure depth**
    - Output parity across PPTX/PDF/HTML confirmed from one source.
    - Layout alias mapping validated for any custom slide masters.

--- a/slides/qplant_sckcen_template.py
+++ b/slides/qplant_sckcen_template.py
@@ -168,7 +168,15 @@ def convert_markdown_bundle(
                 args.extend(["--metadata", f"base_url={settings.base_url}"])
 
             if settings.strict_links:
-                args.extend(["--metadata", "link-strict=true", "--fail-if-warnings"])
+                args.extend(
+                    [
+                        "--metadata",
+                        "strict_links=true",
+                        "--metadata",
+                        "link-strict=true",
+                        "--fail-if-warnings",
+                    ]
+                )
 
             subprocess.run(args, check=True, capture_output=True)
 

--- a/slides/qplant_sckcen_template.py
+++ b/slides/qplant_sckcen_template.py
@@ -153,6 +153,12 @@ def convert_markdown_bundle(
             ]
 
             if fmt == "pptx":
+                if not settings.template_path.exists():
+                    raise FileNotFoundError(
+                        "PPTX reference template not found: "
+                        f"{settings.template_path}. Configure an existing template "
+                        "path or use --dry-run for placeholder output."
+                    )
                 args.extend(["--reference-doc", str(settings.template_path)])
 
             if settings.partner_logo:

--- a/slides/qplant_sckcen_template.py
+++ b/slides/qplant_sckcen_template.py
@@ -165,7 +165,7 @@ def convert_markdown_bundle(
                 args.extend(["--metadata", f"partner_logo={settings.partner_logo}"])
 
             if settings.base_url:
-                args.extend(["--metadata", f"base-url={settings.base_url}"])
+                args.extend(["--metadata", f"base_url={settings.base_url}"])
 
             if settings.strict_links:
                 args.extend(["--metadata", "link-strict=true", "--fail-if-warnings"])


### PR DESCRIPTION
### Motivation

- Ensure CLI-provided template options (`--template`, `--partner-logo`, `--base-url`, `--strict-links`) actually influence Pandoc conversions so generated decks are branded and link-checked as promised. 
- Surface guidance about regulatory gatekeepers and handover artifacts to support CE/ISO validation traceability and contractor responsibilities.

### Description

- Update `convert_markdown_bundle` to accept `settings: TemplateSettings` and apply it when constructing Pandoc invocations. 
- For `pptx` outputs, pass `--reference-doc` using `settings.template_path`, and add metadata flags for `partner_logo` and `base-url` when present. 
- Enforce link strictness by adding `link-strict=true` metadata and `--fail-if-warnings` when `settings.strict_links` is true. 
- Update `build_deck` to pass `settings` through to `convert_markdown_bundle` and continue to embed template metadata into the output `*.metadata.json`. 
- Expand `slides/README.md` with a new **Regulatory gatekeeper context (CE/ISO validation)** section explaining BSI/TÜV roles, add a corrigendum placeholder `CORR-REG-0001` using `shall` wording, provide a delivery-depth handover checklist, and list TODOs for CI/contract follow-ups.

### Testing

- Ran `python -m compileall slides src` and compilation completed successfully. 
- No additional automated unit tests were added; Pandoc invocation behavior is exercised at runtime and guarded by `ensure_pandoc_available` when not in `--dry-run` mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69246aa062c0832e93c9babb72f40b31)