### PR TITLE
Add Core Topic EP dashboard and slide YAML scaffold

### DIFF
--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -75,14 +75,60 @@
     const themes = ['All', ...new Set(data.map(d => d.theme))];
     themes.forEach(t => { const o = document.createElement('option'); o.value=t; o.textContent=t; themeSelect.appendChild(o); });
 
+    function createPill(text) {
+      const span = document.createElement('span');
+      span.className = 'pill';
+      span.textContent = text;
+      return span;
+    }
+
+    function createTopicListItem(item) {
+      const li = document.createElement('li');
+      const strong = document.createElement('strong');
+      strong.textContent = item.epic;
+      li.appendChild(strong);
+      li.appendChild(document.createTextNode(' '));
+      li.appendChild(createPill(item.theme));
+      li.appendChild(document.createTextNode(' '));
+      li.appendChild(createPill(item.status));
+      li.appendChild(document.createElement('br'));
+
+      const summary = document.createElement('span');
+      summary.className = 'muted';
+      summary.textContent = item.summary;
+      li.appendChild(summary);
+      return li;
+    }
+
+    function createPreviewContent(item) {
+      if (!item) {
+        const empty = document.createElement('p');
+        empty.className = 'muted';
+        empty.textContent = 'No topic matches current filter.';
+        return [empty];
+      }
+
+      const heading = document.createElement('h4');
+      heading.textContent = item.epic;
+
+      const paragraph = document.createElement('p');
+      const theme = document.createElement('em');
+      theme.textContent = item.theme;
+      paragraph.appendChild(theme);
+      paragraph.appendChild(document.createTextNode(' — ' + item.summary));
+
+      const pre = document.createElement('pre');
+      pre.textContent = `## ${item.epic}\n- Status: ${item.status}\n- Theme: ${item.theme}`;
+
+      return [heading, paragraph, pre];
+    }
+
     function render() {
       const theme = themeSelect.value;
       const q = searchInput.value.toLowerCase();
       const filtered = data.filter(d => (theme==='All' || d.theme===theme) && JSON.stringify(d).toLowerCase().includes(q));
-      topicList.innerHTML = filtered.map(d => `<li><strong>${d.epic}</strong> <span class="pill">${d.theme}</span> <span class="pill">${d.status}</span><br/><span class="muted">${d.summary}</span></li>`).join('');
-      preview.innerHTML = filtered[0]
-        ? `<h4>${filtered[0].epic}</h4><p><em>${filtered[0].theme}</em> — ${filtered[0].summary}</p><pre>## ${filtered[0].epic}\n- Status: ${filtered[0].status}\n- Theme: ${filtered[0].theme}</pre>`
-        : '<p class="muted">No topic matches current filter.</p>';
+      topicList.replaceChildren(...filtered.map(createTopicListItem));
+      preview.replaceChildren(...createPreviewContent(filtered[0]));
     }
 
     themeSelect.addEventListener('change', render);

--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -60,7 +60,7 @@
   </main>
 
   <script>
-    const data = [
+    const SAMPLE_DATA = [
       {theme:'Reliability', epic:'Lifecycle Cost Governance', status:'active', summary:'RCM + cost baseline + risk scoring.'},
       {theme:'Delivery', epic:'Commissioning Readiness', status:'active', summary:'Factory/site acceptance workflows and readiness gates.'},
       {theme:'Quality', epic:'QA/QC Evidence Chain', status:'planning', summary:'Traceability from requirement to test evidence.'},
@@ -72,8 +72,19 @@
     const topicList = document.getElementById('topicList');
     const preview = document.getElementById('preview');
 
-    const themes = ['All', ...new Set(data.map(d => d.theme))];
-    themes.forEach(t => { const o = document.createElement('option'); o.value=t; o.textContent=t; themeSelect.appendChild(o); });
+    let data = [];
+
+    function init(topics) {
+      data = topics;
+      const themes = ['All', ...new Set(data.map(d => d.theme))];
+      themes.forEach(t => { const o = document.createElement('option'); o.value=t; o.textContent=t; themeSelect.appendChild(o); });
+      render();
+    }
+
+    fetch('topics.json')
+      .then(r => { if (!r.ok) throw new Error('Failed to load topics.json: ' + r.status); return r.json(); })
+      .then(init)
+      .catch(() => init(SAMPLE_DATA));
 
     function createPill(text) {
       const span = document.createElement('span');
@@ -133,7 +144,6 @@
 
     themeSelect.addEventListener('change', render);
     searchInput.addEventListener('input', render);
-    render();
   </script>
 </body>
 </html>

--- a/docs/dashboard.html
+++ b/docs/dashboard.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Core Topic EP Dashboard</title>
+  <style>
+    :root { --bg:#0b1020; --card:#121a30; --txt:#e8edff; --muted:#9fb0e0; --accent:#6ea8ff; }
+    body { margin:0; font-family:Inter,Arial,sans-serif; background:var(--bg); color:var(--txt); }
+    header, main { max-width:1100px; margin:auto; padding:20px; }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:14px; }
+    .card { background:var(--card); border:1px solid #26335f; border-radius:12px; padding:14px; }
+    .muted { color:var(--muted); font-size:.9rem; }
+    button, select, input { background:#1c2750; color:var(--txt); border:1px solid #334887; border-radius:8px; padding:8px 10px; }
+    .pill { display:inline-block; padding:4px 9px; border-radius:999px; border:1px solid #3a4f91; margin:3px 4px 0 0; font-size:.8rem; }
+    a { color:var(--accent); }
+    #topicList li { margin-bottom:6px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Engineering Portal — Core Topic EP Dashboard</h1>
+    <p class="muted">Renamed from legacy HBHelium wording. GitHub Pages-ready static dashboard with JSON-driven interaction.</p>
+    <div class="card">
+      <strong>Suggested naming options</strong><br/>
+      <span class="pill">Core Topic EP Dashboard</span>
+      <span class="pill">Themed Topics & Epics Portal</span>
+      <span class="pill">Engineering Program Epic Hub</span>
+    </div>
+  </header>
+
+  <main>
+    <section class="grid">
+      <article class="card">
+        <h3>Topic Filter</h3>
+        <label for="theme">Theme</label>
+        <select id="theme"></select>
+        <label for="search">Keyword</label>
+        <input id="search" placeholder="type text"/>
+      </article>
+      <article class="card">
+        <h3>Preview</h3>
+        <p class="muted">Shows rendered Markdown-compatible snippets for selected epic.</p>
+        <div id="preview"></div>
+      </article>
+      <article class="card">
+        <h3>Backbone</h3>
+        <ul>
+          <li>HTML + JS interaction layer</li>
+          <li>Python can generate <code>topics.json</code> from markdown/yaml</li>
+          <li>Deploy with GitHub Pages from <code>/docs</code></li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="card" style="margin-top:14px;">
+      <h3>Themed Topics & Epics</h3>
+      <ul id="topicList"></ul>
+    </section>
+  </main>
+
+  <script>
+    const data = [
+      {theme:'Reliability', epic:'Lifecycle Cost Governance', status:'active', summary:'RCM + cost baseline + risk scoring.'},
+      {theme:'Delivery', epic:'Commissioning Readiness', status:'active', summary:'Factory/site acceptance workflows and readiness gates.'},
+      {theme:'Quality', epic:'QA/QC Evidence Chain', status:'planning', summary:'Traceability from requirement to test evidence.'},
+      {theme:'Integration', epic:'GitHub Managed Build Spine', status:'active', summary:'Python/JS pipeline generating markdown + rendered HTML.'}
+    ];
+
+    const themeSelect = document.getElementById('theme');
+    const searchInput = document.getElementById('search');
+    const topicList = document.getElementById('topicList');
+    const preview = document.getElementById('preview');
+
+    const themes = ['All', ...new Set(data.map(d => d.theme))];
+    themes.forEach(t => { const o = document.createElement('option'); o.value=t; o.textContent=t; themeSelect.appendChild(o); });
+
+    function render() {
+      const theme = themeSelect.value;
+      const q = searchInput.value.toLowerCase();
+      const filtered = data.filter(d => (theme==='All' || d.theme===theme) && JSON.stringify(d).toLowerCase().includes(q));
+      topicList.innerHTML = filtered.map(d => `<li><strong>${d.epic}</strong> <span class="pill">${d.theme}</span> <span class="pill">${d.status}</span><br/><span class="muted">${d.summary}</span></li>`).join('');
+      preview.innerHTML = filtered[0]
+        ? `<h4>${filtered[0].epic}</h4><p><em>${filtered[0].theme}</em> — ${filtered[0].summary}</p><pre>## ${filtered[0].epic}\n- Status: ${filtered[0].status}\n- Theme: ${filtered[0].theme}</pre>`
+        : '<p class="muted">No topic matches current filter.</p>';
+    }
+
+    themeSelect.addEventListener('change', render);
+    searchInput.addEventListener('input', render);
+    render();
+  </script>
+</body>
+</html>

--- a/docs/dashboard_topics.md
+++ b/docs/dashboard_topics.md
@@ -14,3 +14,7 @@
 - Core Topic EP Dashboard
 - Themed Topics & Epics Portal
 - Engineering Program Epic Hub
+
+
+## Pending review + parallel track
+Use a dual-PR model: merge a minimal baseline branch, while a parallel `review/followups-*` branch collects all comment-driven updates before final approval. See `docs/review_parallel_track.md`.

--- a/docs/dashboard_topics.md
+++ b/docs/dashboard_topics.md
@@ -3,7 +3,7 @@
 ## GitHub Pages setup
 1. Keep dashboard artifacts in `/docs`.
 2. In repository settings, set Pages source to `main` branch `/docs` folder.
-3. Publish `dashboard.html` as entry page, optionally rename to `index.html`.
+3. Publish the dashboard as `/docs/index.html` for the site root, or keep `dashboard.html` and link to it from an existing `/docs/index.html`.
 
 ## Backbone architecture
 - **Python layer**: aggregates markdown, YAML slide specs, and test status into a `topics.json` file.

--- a/docs/dashboard_topics.md
+++ b/docs/dashboard_topics.md
@@ -1,0 +1,16 @@
+# Core Topic EP Dashboard blueprint
+
+## GitHub Pages setup
+1. Keep dashboard artifacts in `/docs`.
+2. In repository settings, set Pages source to `main` branch `/docs` folder.
+3. Publish `dashboard.html` as entry page, optionally rename to `index.html`.
+
+## Backbone architecture
+- **Python layer**: aggregates markdown, YAML slide specs, and test status into a `topics.json` file.
+- **JavaScript layer**: reads the JSON and provides filtering, search, and rendered previews.
+- **Rendered output**: both markdown and HTML views supported for engineering handover.
+
+## Recommended naming
+- Core Topic EP Dashboard
+- Themed Topics & Epics Portal
+- Engineering Program Epic Hub

--- a/docs/review_parallel_track.md
+++ b/docs/review_parallel_track.md
@@ -1,0 +1,52 @@
+# Pending Review Integration Strategy (GitHub)
+
+This pattern lets you keep delivery moving while isolating unresolved review feedback.
+
+## Goal
+- Merge a stable baseline quickly.
+- Keep reviewer-requested changes decoupled until approved.
+- Avoid blocking mainline release cadence.
+
+## Branch model
+1. `main` (protected): only approved, green CI changes.
+2. `feature/core-topic-ep` (delivery branch): current implementation PR into `main`.
+3. `review/followups-core-topic-ep` (parallel track): all review comments and refactors.
+
+## Recommended flow
+1. Open PR-A from `feature/core-topic-ep` to `main` for "merge-as-is" baseline.
+2. In parallel, create PR-B from `review/followups-core-topic-ep` to `feature/core-topic-ep` (or `main`, your choice).
+3. Apply all comment-driven updates in PR-B.
+4. Use required checks + reviewer approvals on PR-B.
+5. Merge PR-A when baseline is accepted; merge PR-B when comments are resolved.
+
+## Waiting safely for pending review
+- Use draft PR status for PR-B until implementation is complete.
+- Add labels: `pending-review`, `follow-up`, `non-blocking`.
+- Enable branch protection requiring:
+  - 1–2 approvals
+  - passing checks
+  - up-to-date branch before merge
+- Optionally enable auto-merge only after checks and approvals complete.
+
+## Conflict minimization tips
+- Keep PR-A small (naming/content only).
+- Put structural refactors and larger code updates in PR-B.
+- Rebase `review/followups-*` frequently onto latest `main`.
+- Use `CODEOWNERS` for targeted reviewers by directory.
+
+## Example commands
+```bash
+# baseline delivery branch
+git checkout -b feature/core-topic-ep
+
+# parallel follow-up branch
+git checkout -b review/followups-core-topic-ep
+
+# after baseline merges
+git fetch origin
+git checkout review/followups-core-topic-ep
+git rebase origin/main
+```
+
+## Suggested policy statement
+"We use dual-track PRs: baseline PRs for immediate safe merge, and follow-up PRs for comment resolution and deeper improvements."

--- a/slides/src/core-topic-ep-slides.yaml
+++ b/slides/src/core-topic-ep-slides.yaml
@@ -1,0 +1,40 @@
+meta:
+  title: "Core Topic EP Dashboard"
+  subtitle: "Themed Topics and Epics"
+  author: "Engineering Portal"
+  format: "html-slides"
+slides:
+  - slide_number: 1
+    title: "Portal Rename"
+    subtitle: "From HBHelium legacy label to Core Topic EP"
+    annotations:
+      - "Use concise name focused on epics and themes"
+      - "Keep acronym EP for continuity"
+    text_block: |
+      The legacy name is replaced by **Core Topic EP Dashboard**.
+      This aligns the portal with engineering themes, epic tracking,
+      and GitHub-hosted collaboration.
+
+  - slide_number: 2
+    title: "System Structure"
+    subtitle: "HTML interaction + GitHub managed backbone"
+    annotations:
+      - "Static frontend served from GitHub Pages"
+      - "Python scripts produce JSON and markdown artifacts"
+      - "JavaScript handles filtering and preview rendering"
+    text_block: |
+      Users interact through HTML components while the backend content
+      is generated from Python and markdown/yaml sources in-repo.
+
+  - slide_number: 3
+    title: "Content blocks"
+    subtitle: "Text and block layout model"
+    annotations:
+      - "title"
+      - "subtitle"
+      - "slide_number"
+      - "annotations"
+      - "text_block"
+    text_block: |
+      Each slide is represented as structured YAML so it can be converted
+      to markdown, reveal-style HTML, or PPTX templates.


### PR DESCRIPTION
### Motivation
- Replace the legacy HBHelium label with a clearer, GitHub Pages-friendly portal identity focused on core topics and epics.
- Provide a lightweight static HTML+JS frontend that teams can use for quick browsing, filtering and markdown-style previews of epics.
- Ship a repo-managed content backbone and a slide-oriented YAML model so content can be produced from Python and rendered to HTML/slide formats.

### Description
- Added `docs/dashboard.html` which implements a dark-themed, static interactive dashboard with theme/keyword filtering and a markdown-style preview pane driven by in-page JSON data.
- Added `docs/dashboard_topics.md` which documents GitHub Pages setup, the Python/JavaScript backbone roles, and recommended naming options for the portal.
- Added `slides/src/core-topic-ep-slides.yaml` which defines a reusable slide schema (`title`, `subtitle`, `slide_number`, `annotations`, `text_block`) suitable for conversion to HTML, markdown, or PPTX via the existing slide tooling.
- The frontend expects a repository-produced `topics.json` (Python layer) and uses simple DOM-based filtering and preview rendering so it can be deployed directly from `/docs` on GitHub Pages.

### Testing
- Ran `pytest -q` and the test suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a02ce5040ec832e9b8c90ac2a8e385b)