### PR TITLE
docs: add clean handover pack usage guide

### DIFF
--- a/99_handover/CLEAN_HANDOVER_PACK.md
+++ b/99_handover/CLEAN_HANDOVER_PACK.md
@@ -1,6 +1,6 @@
 # Clean Handover Pack Usage
 
-Use the **clean handover pack** and avoid the rough tuple flow.
+Use the **clean handover pack** and avoid the rough tuple flow (that is, passing fragmented, loosely structured handover inputs instead of the packaged minimal copy-paste handover).
 
 ## Recommended operator flow
 

--- a/99_handover/CLEAN_HANDOVER_PACK.md
+++ b/99_handover/CLEAN_HANDOVER_PACK.md
@@ -11,13 +11,15 @@ Use the **clean handover pack** and avoid the rough tuple flow.
 
 The clean **CODEX Handover Manifest Glob Pack** should include:
 
+> Note: the manifest and policy filenames below refer to artifacts bundled in the external clean handover pack. They are not expected to exist as tracked files in this repository unless they have been copied in as part of that bundle.
+
 - master CODEX prompt
 - repo target structure
 - SAME vs SIMILAR branch rules
-- root `MANIFEST.json`
-- tool `MANIFEST.json`
-- `GLOB_POLICY.md`
-- `BACKBONE_POLICY.md`
+- root `MANIFEST.json` (handover-pack artifact)
+- tool `MANIFEST.json` (handover-pack artifact)
+- `GLOB_POLICY.md` (handover-pack artifact)
+- `BACKBONE_POLICY.md` (handover-pack artifact)
 - CI workflow
 - GitHub Pages workflow
 - acceptance checklist

--- a/99_handover/CLEAN_HANDOVER_PACK.md
+++ b/99_handover/CLEAN_HANDOVER_PACK.md
@@ -1,0 +1,28 @@
+# Clean Handover Pack Usage
+
+Use the **clean handover pack** and avoid the rough tuple flow.
+
+## Recommended operator flow
+
+1. Start by pasting the **Minimal Copy-Paste Version** into CODEX.
+2. Provide the full handover pack as supporting context only if more detail is needed.
+
+## Pack contents checklist
+
+The clean **CODEX Handover Manifest Glob Pack** should include:
+
+- master CODEX prompt
+- repo target structure
+- SAME vs SIMILAR branch rules
+- root `MANIFEST.json`
+- tool `MANIFEST.json`
+- `GLOB_POLICY.md`
+- `BACKBONE_POLICY.md`
+- CI workflow
+- GitHub Pages workflow
+- acceptance checklist
+- minimal copy-paste CODEX block
+
+## Selection rule
+
+**Best option:** paste the **Minimal Copy-Paste Version** section into CODEX first, then add the full pack only as needed.

--- a/99_handover/CLEAN_HANDOVER_PACK.md
+++ b/99_handover/CLEAN_HANDOVER_PACK.md
@@ -4,8 +4,30 @@ Use the **clean handover pack** and avoid the rough tuple flow (that is, passing
 
 ## Recommended operator flow
 
-1. Start by pasting the **Minimal Copy-Paste Version** into CODEX.
+1. Start by pasting the **Minimal Copy-Paste Block** (see below) into CODEX.
 2. Provide the full handover pack as supporting context only if more detail is needed.
+
+## Minimal Copy-Paste Block
+
+Copy and paste the block below verbatim at the start of every new CODEX interaction to give the agent essential project context before you supply any additional files.
+
+```
+## CODEX Minimal Context — HELIUM_VCR_UHP v1.3.0
+
+Repo: GBOGEB/CODEX | Branch: main
+Project: Helium UHP distribution system — VCR face-seal (/FS) policy and P&ID
+
+Key rules:
+  - Naming: QRB.A/.B/.D/.E; QINFRA.U/W/S; WCS.HP/LP/VLP (dots, not dashes)
+  - All serviceable joints: metal gasket face-seal (/FS, VCR-compatible); new gasket at every remake
+  - DBB purge: pull to ≤50 mbar(a), He backfill to 1.05 bar(a), analyser confirm
+  - Leakage limit: per Table 6; verified by He MS test
+  - Safety populations: 60+5 BD, 180+30 PSV; S-line PSV ≥200 g/s @ 300 K to WCS.LP
+
+Outputs: HTML dashboard · Markdown handover · PDF · RTM · JSON/YAML · GitHub Pages
+Source of truth: Markdown + YAML + JSON + Python calculation engine
+Start here: OUTPUT_MANIFEST.json → 01_requirements/RTM.csv → 02_design/MASTER_FACE_SEAL_POLICY.md
+```
 
 ## Pack contents checklist
 
@@ -23,8 +45,8 @@ The clean **CODEX Handover Manifest Glob Pack** should include:
 - CI workflow
 - GitHub Pages workflow
 - acceptance checklist
-- minimal copy-paste CODEX block
+- Minimal Copy-Paste Block (see above)
 
 ## Selection rule
 
-**Best option:** paste the **Minimal Copy-Paste Version** section into CODEX first, then add the full pack only as needed.
+**Best option:** paste the **Minimal Copy-Paste Block** into CODEX first, then add the full pack only as needed.


### PR DESCRIPTION
### Motivation
- Formalize operator guidance to prefer the clean CODEX Handover Manifest Glob Pack and to start interactions by pasting the `Minimal Copy-Paste Version` before providing the full pack as supporting context.

### Description
- Add `99_handover/CLEAN_HANDOVER_PACK.md` documenting the recommended operator flow, a checklist of expected pack components (master prompt, branch rules, `MANIFEST.json` files, `GLOB_POLICY.md`, `BACKBONE_POLICY.md`, CI and GitHub Pages workflows, acceptance checklist, and the minimal copy-paste block), and the selection rule to prefer the minimal copy-paste first.

### Testing
- No automated tests were run; this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0309c2abd8832e9b88480c9ff218f9)