### PR TITLE
Add GitHub Pages portal, manifest, policies, CI workflows and validation scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+
+      - name: Build dashboard/pages
+        run: |
+          if [ -f tools/losses/src/build_all.py ]; then
+            python tools/losses/src/build_all.py
+          fi
+
+      - name: Run tests
+        run: |
+          pytest -q
+
+      - name: Check manifest
+        run: |
+          python scripts/check_manifest.py
+
+      - name: Check glob policy
+        run: |
+          python scripts/check_globs.py
+
+      - name: Check stale artifacts
+        run: |
+          python scripts/check_stale.py
+
+      - name: Check links
+        run: |
+          python scripts/check_links.py

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,10 +44,20 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
+      - name: Stage Pages artifact
+        run: |
+          rm -rf _site
+          mkdir -p _site
+          cp -a docs/. _site/
+          if [ -d outputs ]; then
+            mkdir -p _site/outputs
+            cp -a outputs/. _site/outputs/
+          fi
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs
+          path: _site
 
   deploy:
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,61 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+
+      - name: Build verified Pages output
+        run: |
+          if [ -f tools/losses/src/build_all.py ]; then
+            python tools/losses/src/build_all.py
+          fi
+          python scripts/check_manifest.py
+          python scripts/check_globs.py
+          python scripts/check_stale.py
+          python scripts/check_links.py
+          pytest -q
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/BACKBONE_POLICY.md
+++ b/BACKBONE_POLICY.md
@@ -1,0 +1,50 @@
+# Backbone Policy
+
+## Protected backbone
+
+The following are canonical and must not be renamed or replaced without explicit migration approval:
+
+```text
+docs/index.html
+docs/dashboard.html
+docs/plots/index.html
+tools/losses/src/build_all.py
+MANIFEST.json
+GLOB_POLICY.md
+.github/workflows/pages.yml
+```
+
+## Public URL stability
+
+Published URLs are part of the user interface. Do not rename public files unless:
+
+1. a redirect or replacement link is provided;
+2. the manifest is updated;
+3. the regression page documents the change;
+4. link checks pass.
+
+## Canonical promotion
+
+Experimental dashboards may only become canonical after:
+
+```text
+[ ] feature parity check
+[ ] visual comparison
+[ ] data/schema compatibility review
+[ ] regression comparison
+[ ] stale artifact check
+[ ] manifest update
+[ ] public URL review
+[ ] PR approval
+```
+
+## No silent replacement
+
+Never overwrite a verified dashboard with a different semantic dashboard under the same filename without recording the change in:
+
+```text
+MANIFEST.json
+CHANGELOG.md
+docs/regression.html
+docs/verification.html
+```

--- a/GLOB_POLICY.md
+++ b/GLOB_POLICY.md
@@ -1,0 +1,116 @@
+# Glob Policy
+
+## Purpose
+
+This policy defines which files are source, generated, published, archived, or forbidden. It prevents stale outputs, duplicate dashboard variants, broken Pages links, and local-folder drift.
+
+## Source files
+
+Allowed source globs:
+
+```text
+README.md
+LICENSE
+NOTICE.md
+TOOL_INDEX.md
+VERSION.json
+MANIFEST.json
+BACKBONE_POLICY.md
+.github/workflows/*.yml
+schema/*.json
+scripts/*.py
+tests/*.py
+tools/*/README.md
+tools/*/VERSION.json
+tools/*/MANIFEST.json
+tools/*/src/**/*.py
+tools/*/data/**/*.json
+tools/*/data/**/*.csv
+tools/*/assets/**/*
+tools/*/tests/**/*.py
+```
+
+## Published GitHub Pages files
+
+Allowed published globs:
+
+```text
+docs/index.html
+docs/dashboard.html
+docs/handover.html
+docs/verification.html
+docs/regression.html
+docs/traceability.html
+docs/manifest.html
+docs/plots/index.html
+docs/plots/*.html
+docs/assets/**/*
+```
+
+## Local generated files
+
+Allowed local generated globs:
+
+```text
+tools/*/outputs/**/*
+tools/*/reports/**/*
+```
+
+These may be committed only if explicitly required for traceability or release evidence.
+
+## Release snapshots
+
+Allowed release globs:
+
+```text
+releases/**/MANIFEST.json
+releases/**/README.md
+releases/**/*.html
+releases/**/*.pdf
+releases/**/*.json
+```
+
+Release snapshots are immutable once tagged.
+
+## Archive files
+
+Allowed archive globs:
+
+```text
+archive/retired_artifacts/**/*
+```
+
+Archived files must not be linked as canonical live outputs.
+
+## Forbidden ambiguity globs
+
+The following patterns are forbidden unless explicitly justified in a migration note:
+
+```text
+**/final/**
+**/final_final/**
+**/latest/**
+**/new_dashboard/**
+**/dashboard_old/**
+**/dashboard_new/**
+**/copy*/**
+**/*backup*/**
+**/*_old.*
+**/*_new.*
+**/*_final.*
+**/*_latest.*
+```
+
+## Required checks
+
+Every PR must verify:
+
+```text
+no forbidden ambiguity globs
+no duplicate canonical dashboard files
+no orphan published HTML files
+no broken relative links
+no stale plot files
+no missing manifest entries
+no untracked public entrypoints
+```

--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -26,7 +26,10 @@
     "docs/regression.html",
     "docs/traceability.html",
     "docs/manifest.html",
-    "docs/plots/index.html"
+    "docs/plots/index.html",
+    "docs/plots/*.html",
+    "docs/leak_baseline/index.html",
+    "docs/HUMAN.*.html"
   ],
   "controls": {
     "link_check_required": true,

--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -1,0 +1,45 @@
+{
+  "project": "Q_Engineering_Tools",
+  "canonical_entrypoint": "docs/index.html",
+  "hosted_entrypoint": "https://<github-user-or-org>.github.io/<repo>/",
+  "repository_role": "engineering_source_of_truth",
+  "pages_role": "curated_verified_user_portal",
+  "status": "active",
+  "version": "0.1.0",
+  "dashboard_lineage": {
+    "canonical_dashboard": "losses",
+    "current_generation": "v3",
+    "same_branch_policy": "bugfix_or_equivalent_improvement_only",
+    "similar_branch_policy": "parallel_variant_requires_comparison_and_promotion_gate"
+  },
+  "build": {
+    "master_builder": "tools/losses/src/build_all.py",
+    "publish_folder": "docs/",
+    "deterministic_required": true,
+    "idempotent_required": true
+  },
+  "published_pages": [
+    "docs/index.html",
+    "docs/dashboard.html",
+    "docs/handover.html",
+    "docs/verification.html",
+    "docs/regression.html",
+    "docs/traceability.html",
+    "docs/manifest.html",
+    "docs/plots/index.html"
+  ],
+  "controls": {
+    "link_check_required": true,
+    "stale_check_required": true,
+    "manifest_check_required": true,
+    "glob_policy_required": true,
+    "regression_check_required": true,
+    "post_publish_smoke_test_required": true
+  },
+  "promotion_rules": {
+    "main_must_be_deployable": true,
+    "pages_must_be_verified": true,
+    "experimental_outputs_must_not_replace_canonical_silently": true,
+    "public_urls_should_remain_stable": true
+  }
+}

--- a/docs/handover.html
+++ b/docs/handover.html
@@ -1,0 +1,1 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8" /><title>Handover</title></head><body><h1>Handover</h1><p>Placeholder handover page for governance portal.</p><p><a href="index.html">Back to portal</a></p></body></html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Q Engineering Tools Portal</title>
+</head>
+<body>
+  <h1>Q Engineering Tools Portal</h1>
+  <p>Canonical GitHub Pages entry point for curated engineering outputs.</p>
+  <ul>
+    <li><a href="dashboard.html">Dashboard</a></li>
+    <li><a href="plots/index.html">Plots</a></li>
+    <li><a href="handover.html">Handover</a></li>
+    <li><a href="verification.html">Verification</a></li>
+    <li><a href="regression.html">Regression</a></li>
+    <li><a href="traceability.html">Traceability</a></li>
+    <li><a href="manifest.html">Manifest</a></li>
+  </ul>
+</body>
+</html>

--- a/docs/manifest.html
+++ b/docs/manifest.html
@@ -1,0 +1,1 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8" /><title>Manifest</title></head><body><h1>Manifest</h1><p>Placeholder manifest page for governance portal.</p><p><a href="index.html">Back to portal</a></p></body></html>

--- a/docs/plots/01_leak_vs_loss.html
+++ b/docs/plots/01_leak_vs_loss.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset='utf-8'><title>01_leak_vs_loss</title></head><body><h1>01_leak_vs_loss</h1><p>Plot placeholder.</p><a href='index.html'>Back to plots index</a></body></html>

--- a/docs/plots/02_temperature_pressure_effects.html
+++ b/docs/plots/02_temperature_pressure_effects.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset='utf-8'><title>02_temperature_pressure_effects</title></head><body><h1>02_temperature_pressure_effects</h1><p>Plot placeholder.</p><a href='index.html'>Back to plots index</a></body></html>

--- a/docs/plots/03_cost_vs_leaktightness.html
+++ b/docs/plots/03_cost_vs_leaktightness.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset='utf-8'><title>03_cost_vs_leaktightness</title></head><body><h1>03_cost_vs_leaktightness</h1><p>Plot placeholder.</p><a href='index.html'>Back to plots index</a></body></html>

--- a/docs/plots/04_fleet_sensitivity.html
+++ b/docs/plots/04_fleet_sensitivity.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset='utf-8'><title>04_fleet_sensitivity</title></head><body><h1>04_fleet_sensitivity</h1><p>Plot placeholder.</p><a href='index.html'>Back to plots index</a></body></html>

--- a/docs/plots/05_reliability.html
+++ b/docs/plots/05_reliability.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta charset='utf-8'><title>05_reliability</title></head><body><h1>05_reliability</h1><p>Plot placeholder.</p><a href='index.html'>Back to plots index</a></body></html>

--- a/docs/plots/index.html
+++ b/docs/plots/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>Plots</title></head>
+<body>
+  <h1>Plots Index</h1>
+  <ul>
+    <li><a href="../index.html">Back to portal</a></li>
+    <li><a href="01_leak_vs_loss.html">01 Leak vs Loss</a></li>
+    <li><a href="02_temperature_pressure_effects.html">02 Temperature and Pressure Effects</a></li>
+    <li><a href="03_cost_vs_leaktightness.html">03 Cost vs Leaktightness</a></li>
+    <li><a href="04_fleet_sensitivity.html">04 Fleet Sensitivity</a></li>
+    <li><a href="05_reliability.html">05 Reliability</a></li>
+  </ul>
+</body>
+</html>

--- a/docs/regression.html
+++ b/docs/regression.html
@@ -1,0 +1,1 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8" /><title>Regression</title></head><body><h1>Regression</h1><p>Placeholder regression page for governance portal.</p><p><a href="index.html">Back to portal</a></p></body></html>

--- a/docs/traceability.html
+++ b/docs/traceability.html
@@ -1,0 +1,1 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8" /><title>Traceability</title></head><body><h1>Traceability</h1><p>Placeholder traceability page for governance portal.</p><p><a href="index.html">Back to portal</a></p></body></html>

--- a/docs/verification.html
+++ b/docs/verification.html
@@ -1,0 +1,1 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8" /><title>Verification</title></head><body><h1>Verification</h1><p>Placeholder verification page for governance portal.</p><p><a href="index.html">Back to portal</a></p></body></html>

--- a/scripts/check_globs.py
+++ b/scripts/check_globs.py
@@ -10,6 +10,7 @@ forbidden_segment_exact = {
 }
 forbidden_filename_tokens = {"_old.", "_new.", "_final.", "_latest."}
 allowlist = {"output/handover_final"}
+MAX_VIOLATIONS_DISPLAYED = 50
 violations = []
 for p in Path(".").rglob("*"):
     s = str(p).replace("\\", "/")
@@ -31,6 +32,9 @@ for p in Path(".").rglob("*"):
         violations.append(s)
 
 if violations:
-    raise SystemExit("forbidden ambiguity paths found:\n" + "\n".join(sorted(violations)[:50]))
+    raise SystemExit(
+        "forbidden ambiguity paths found:\n"
+        + "\n".join(sorted(violations)[:MAX_VIOLATIONS_DISPLAYED])
+    )
 
 print("glob policy check passed")

--- a/scripts/check_globs.py
+++ b/scripts/check_globs.py
@@ -16,7 +16,7 @@ for p in Path(".").rglob("*"):
     s = str(p).replace("\\", "/")
     name = p.name.lower()
     lowered = s.lower()
-    segments = [part for part in lowered.split("/") if part]
+    segments = [part.lower() for part in p.parts if part]
     if lowered in allowlist:
         continue
     has_forbidden_segment = any(part in forbidden_segment_exact for part in segments)

--- a/scripts/check_globs.py
+++ b/scripts/check_globs.py
@@ -16,7 +16,7 @@ for p in Path(".").rglob("*"):
     name = p.name.lower()
     lowered = s.lower()
     segments = [part for part in lowered.split("/") if part]
-    if s in allowlist:
+    if lowered in allowlist:
         continue
     has_forbidden_segment = any(part in forbidden_segment_exact for part in segments)
     has_copy_segment = any(part.startswith("copy") for part in segments)

--- a/scripts/check_globs.py
+++ b/scripts/check_globs.py
@@ -1,14 +1,40 @@
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
-forbidden = ["final_final", "latest", "new_dashboard", "dashboard_old", "dashboard_new", "copy", "backup", "_old.", "_new.", "_final.", "_latest."]
+forbidden_patterns = [
+    "**/final_final/**",
+    "**/latest/**",
+    "**/new_dashboard/**",
+    "**/dashboard_old/**",
+    "**/dashboard_new/**",
+    "**/copy*/**",
+    "**/backup/**",
+    "**/*_old.*",
+    "**/*_new.*",
+    "**/*_final.*",
+    "**/*_latest.*",
+]
 allowlist = {"output/handover_final"}
 violations = []
+
+
+def matches_forbidden_pattern(path_str: str) -> bool:
+    path = PurePosixPath(path_str.lower())
+    for pattern in forbidden_patterns:
+        normalized_pattern = pattern.lower()
+        if normalized_pattern.endswith('/**'):
+            base_pattern = normalized_pattern[:-3]
+            if path.match(base_pattern) or any(parent.match(base_pattern) for parent in path.parents):
+                return True
+        elif path.match(normalized_pattern):
+            return True
+    return False
+
+
 for p in Path('.').rglob('*'):
     s = str(p).replace('\\', '/')
-    name = p.name.lower()
     if s in allowlist:
         continue
-    if any(token in name for token in forbidden):
+    if matches_forbidden_pattern(s):
         violations.append(s)
 
 if violations:

--- a/scripts/check_globs.py
+++ b/scripts/check_globs.py
@@ -1,43 +1,36 @@
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
-forbidden_patterns = [
-    "**/final_final/**",
-    "**/latest/**",
-    "**/new_dashboard/**",
-    "**/dashboard_old/**",
-    "**/dashboard_new/**",
-    "**/copy*/**",
-    "**/backup/**",
-    "**/*_old.*",
-    "**/*_new.*",
-    "**/*_final.*",
-    "**/*_latest.*",
-]
+forbidden_segment_exact = {
+    "final",
+    "final_final",
+    "latest",
+    "new_dashboard",
+    "dashboard_old",
+    "dashboard_new",
+}
+forbidden_filename_tokens = {"_old.", "_new.", "_final.", "_latest."}
 allowlist = {"output/handover_final"}
 violations = []
-
-
-def matches_forbidden_pattern(path_str: str) -> bool:
-    path = PurePosixPath(path_str.lower())
-    for pattern in forbidden_patterns:
-        normalized_pattern = pattern.lower()
-        if normalized_pattern.endswith('/**'):
-            base_pattern = normalized_pattern[:-3]
-            if path.match(base_pattern) or any(parent.match(base_pattern) for parent in path.parents):
-                return True
-        elif path.match(normalized_pattern):
-            return True
-    return False
-
-
-for p in Path('.').rglob('*'):
-    s = str(p).replace('\\', '/')
+for p in Path(".").rglob("*"):
+    s = str(p).replace("\\", "/")
+    name = p.name.lower()
+    lowered = s.lower()
+    segments = [part for part in lowered.split("/") if part]
     if s in allowlist:
         continue
-    if matches_forbidden_pattern(s):
+    has_forbidden_segment = any(part in forbidden_segment_exact for part in segments)
+    has_copy_segment = any(part.startswith("copy") for part in segments)
+    has_backup_segment = any("backup" in part for part in segments)
+    has_forbidden_filename = any(token in name for token in forbidden_filename_tokens)
+    if (
+        has_forbidden_segment
+        or has_copy_segment
+        or has_backup_segment
+        or has_forbidden_filename
+    ):
         violations.append(s)
 
 if violations:
-    raise SystemExit("forbidden ambiguity paths found:\n" + "\n".join(violations[:50]))
+    raise SystemExit("forbidden ambiguity paths found:\n" + "\n".join(sorted(violations)[:50]))
 
 print("glob policy check passed")

--- a/scripts/check_globs.py
+++ b/scripts/check_globs.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+forbidden = ["final_final", "latest", "new_dashboard", "dashboard_old", "dashboard_new", "copy", "backup", "_old.", "_new.", "_final.", "_latest."]
+allowlist = {"output/handover_final"}
+violations = []
+for p in Path('.').rglob('*'):
+    s = str(p).replace('\\', '/')
+    name = p.name.lower()
+    if s in allowlist:
+        continue
+    if any(token in name for token in forbidden):
+        violations.append(s)
+
+if violations:
+    raise SystemExit("forbidden ambiguity paths found:\n" + "\n".join(violations[:50]))
+
+print("glob policy check passed")

--- a/scripts/check_globs.py
+++ b/scripts/check_globs.py
@@ -15,9 +15,8 @@ violations = []
 for p in Path(".").rglob("*"):
     s = str(p).replace("\\", "/")
     name = p.name.lower()
-    lowered = s.lower()
     segments = [part.lower() for part in p.parts if part]
-    if lowered in allowlist:
+    if s.lower() in allowlist:
         continue
     has_forbidden_segment = any(part in forbidden_segment_exact for part in segments)
     has_copy_segment = any(part.startswith("copy") for part in segments)

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -11,14 +11,26 @@ class LinkParser(HTMLParser):
             if href:
                 self.links.append(href)
 
+docs_root = Path('docs').resolve()
 errors = []
-for html in Path('docs').rglob('*.html'):
+for html in docs_root.rglob('*.html'):
     parser = LinkParser()
     parser.feed(html.read_text(encoding='utf-8', errors='ignore'))
     for href in parser.links:
-        if href.startswith(('http://','https://','#','mailto:')):
+        if href.startswith(('http://', 'https://', '#', 'mailto:')):
             continue
-        target = (html.parent / href).resolve()
+        path_href = href.split('#', 1)[0].split('?', 1)[0]
+        if not path_href:
+            continue
+        if path_href.startswith('/'):
+            target = (docs_root / path_href.lstrip('/')).resolve()
+        else:
+            target = (html.parent / path_href).resolve()
+        try:
+            target.relative_to(docs_root)
+        except ValueError:
+            errors.append(f"{html}: link escapes docs root -> {href}")
+            continue
         if not target.exists():
             errors.append(f"{html}: broken link -> {href}")
 

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -12,6 +12,8 @@ class LinkParser(HTMLParser):
                 self.links.append(href)
 
 docs_root = Path('docs').resolve()
+repo_root = Path('.').resolve()
+allowed_site_roots = ('outputs',)
 errors = []
 for html in docs_root.rglob('*.html'):
     parser = LinkParser()
@@ -29,6 +31,15 @@ for html in docs_root.rglob('*.html'):
         try:
             target.relative_to(docs_root)
         except ValueError:
+            try:
+                target.relative_to(repo_root)
+                if any(
+                    target.is_relative_to(repo_root / root)
+                    for root in allowed_site_roots
+                ) and target.exists():
+                    continue
+            except ValueError:
+                pass
             errors.append(f"{html}: link escapes docs root -> {href}")
             continue
         if not target.exists():

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -1,0 +1,27 @@
+from html.parser import HTMLParser
+from pathlib import Path
+
+class LinkParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.links = []
+    def handle_starttag(self, tag, attrs):
+        if tag == 'a':
+            href = dict(attrs).get('href')
+            if href:
+                self.links.append(href)
+
+errors = []
+for html in Path('docs').rglob('*.html'):
+    parser = LinkParser()
+    parser.feed(html.read_text(encoding='utf-8', errors='ignore'))
+    for href in parser.links:
+        if href.startswith(('http://','https://','#','mailto:')):
+            continue
+        target = (html.parent / href).resolve()
+        if not target.exists():
+            errors.append(f"{html}: broken link -> {href}")
+
+if errors:
+    raise SystemExit("\n".join(errors[:100]))
+print("link check passed")

--- a/scripts/check_manifest.py
+++ b/scripts/check_manifest.py
@@ -19,16 +19,32 @@ published_pages = obj.get("published_pages")
 if not isinstance(published_pages, list) or not published_pages:
     raise SystemExit("published_pages must be a non-empty list")
 
-non_string_pages = [page for page in published_pages if not isinstance(page, str)]
-if non_string_pages:
-    raise SystemExit("published_pages must contain only string paths")
-
-missing_required_pages = [path for path in required if path not in published_pages]
-if missing_required_pages:
+bad_entries = [
+    page
+    for page in published_pages
+    if not isinstance(page, str) or not page.strip() or not page.startswith("docs/")
+]
+if bad_entries:
     raise SystemExit(
-        "published_pages missing required entrypoints: "
-        + ", ".join(missing_required_pages)
+        "published_pages contains invalid entries:\n"
+        + "\n".join(str(p) for p in bad_entries[:50])
     )
+
+missing_required = [path for path in required if path not in published_pages]
+if missing_required:
+    raise SystemExit(
+        "published_pages missing required entrypoints:\n"
+        + "\n".join(missing_required)
+    )
+
+seen = set()
+duplicates = []
+for page in published_pages:
+    if page in seen and page not in duplicates:
+        duplicates.append(page)
+    seen.add(page)
+if duplicates:
+    raise SystemExit("published_pages contains duplicates:\n" + "\n".join(duplicates))
 
 for path in required:
     if not Path(path).exists():

--- a/scripts/check_manifest.py
+++ b/scripts/check_manifest.py
@@ -15,6 +15,21 @@ obj = json.loads(manifest.read_text(encoding="utf-8"))
 if obj.get("canonical_entrypoint") != "docs/index.html":
     raise SystemExit("canonical_entrypoint must be docs/index.html")
 
+published_pages = obj.get("published_pages")
+if not isinstance(published_pages, list) or not published_pages:
+    raise SystemExit("published_pages must be a non-empty list")
+
+non_string_pages = [page for page in published_pages if not isinstance(page, str)]
+if non_string_pages:
+    raise SystemExit("published_pages must contain only string paths")
+
+missing_required_pages = [path for path in required if path not in published_pages]
+if missing_required_pages:
+    raise SystemExit(
+        "published_pages missing required entrypoints: "
+        + ", ".join(missing_required_pages)
+    )
+
 for path in required:
     if not Path(path).exists():
         raise SystemExit(f"required path missing: {path}")

--- a/scripts/check_manifest.py
+++ b/scripts/check_manifest.py
@@ -6,6 +6,7 @@ required = [
     "docs/dashboard.html",
     "docs/plots/index.html",
 ]
+MAX_ERROR_ENTRIES = 50
 
 manifest = Path("MANIFEST.json")
 if not manifest.exists():
@@ -27,7 +28,7 @@ bad_entries = [
 if bad_entries:
     raise SystemExit(
         "published_pages contains invalid entries:\n"
-        + "\n".join(str(p) for p in bad_entries[:50])
+        + "\n".join(str(p) for p in bad_entries[:MAX_ERROR_ENTRIES])
     )
 
 missing_required = [path for path in required if path not in published_pages]

--- a/scripts/check_manifest.py
+++ b/scripts/check_manifest.py
@@ -28,7 +28,7 @@ bad_entries = [
 if bad_entries:
     raise SystemExit(
         "published_pages contains invalid entries:\n"
-        + "\n".join(str(p) for p in bad_entries[:MAX_ERROR_ENTRIES])
+        + "\n".join(p for p in bad_entries[:MAX_ERROR_ENTRIES])
     )
 
 missing_required = [path for path in required if path not in published_pages]

--- a/scripts/check_manifest.py
+++ b/scripts/check_manifest.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+required = [
+    "docs/index.html",
+    "docs/dashboard.html",
+    "docs/plots/index.html",
+]
+
+manifest = Path("MANIFEST.json")
+if not manifest.exists():
+    raise SystemExit("MANIFEST.json missing")
+
+obj = json.loads(manifest.read_text(encoding="utf-8"))
+if obj.get("canonical_entrypoint") != "docs/index.html":
+    raise SystemExit("canonical_entrypoint must be docs/index.html")
+
+for path in required:
+    if not Path(path).exists():
+        raise SystemExit(f"required path missing: {path}")
+
+print("manifest check passed")

--- a/scripts/check_manifest.py
+++ b/scripts/check_manifest.py
@@ -39,10 +39,12 @@ if missing_required:
     )
 
 seen = set()
+duplicate_set = set()
 duplicates = []
 for page in published_pages:
-    if page in seen and page not in duplicates:
+    if page in seen and page not in duplicate_set:
         duplicates.append(page)
+        duplicate_set.add(page)
     seen.add(page)
 if duplicates:
     raise SystemExit("published_pages contains duplicates:\n" + "\n".join(duplicates))

--- a/scripts/check_stale.py
+++ b/scripts/check_stale.py
@@ -2,9 +2,25 @@ import json
 from pathlib import Path
 
 manifest = json.loads(Path('MANIFEST.json').read_text(encoding='utf-8'))
-published = set(manifest.get('published_pages', []))
+published = manifest.get('published_pages', [])
+
+seen = set()
+duplicates = []
+for page in published:
+    if page in seen and page not in duplicates:
+        duplicates.append(page)
+    seen.add(page)
+if duplicates:
+    raise SystemExit('Duplicate published pages in manifest:\n' + '\n'.join(duplicates))
+
 missing = [p for p in published if not Path(p).exists()]
 if missing:
     raise SystemExit('Missing published pages from manifest:\n' + '\n'.join(missing))
+
+published_html = {Path(p).as_posix() for p in published}
+deployed_html = sorted(path.as_posix() for path in Path('docs').rglob('*.html'))
+orphaned = [path for path in deployed_html if path not in published_html]
+if orphaned:
+    raise SystemExit('Untracked deployed HTML pages under docs/:\n' + '\n'.join(orphaned))
 
 print('stale check passed')

--- a/scripts/check_stale.py
+++ b/scripts/check_stale.py
@@ -1,0 +1,10 @@
+import json
+from pathlib import Path
+
+manifest = json.loads(Path('MANIFEST.json').read_text(encoding='utf-8'))
+published = set(manifest.get('published_pages', []))
+missing = [p for p in published if not Path(p).exists()]
+if missing:
+    raise SystemExit('Missing published pages from manifest:\n' + '\n'.join(missing))
+
+print('stale check passed')

--- a/scripts/check_stale.py
+++ b/scripts/check_stale.py
@@ -1,26 +1,47 @@
 import json
+from fnmatch import fnmatch
 from pathlib import Path
 
-manifest = json.loads(Path('MANIFEST.json').read_text(encoding='utf-8'))
-published = manifest.get('published_pages', [])
+manifest = json.loads(Path("MANIFEST.json").read_text(encoding="utf-8"))
+published = manifest.get("published_pages", [])
+if not isinstance(published, list) or not published:
+    raise SystemExit("published_pages must be a non-empty list")
 
-seen = set()
-duplicates = []
-for page in published:
-    if page in seen and page not in duplicates:
-        duplicates.append(page)
-    seen.add(page)
-if duplicates:
-    raise SystemExit('Duplicate published pages in manifest:\n' + '\n'.join(duplicates))
+deployed_html = sorted(
+    str(path).replace("\\", "/")
+    for path in Path("docs").rglob("*.html")
+)
 
-missing = [p for p in published if not Path(p).exists()]
+tracked_html = set()
+missing = []
+for pattern in published:
+    pattern_matches = [path for path in deployed_html if fnmatch(path, pattern)]
+    if not pattern_matches:
+        missing.append(pattern)
+    tracked_html.update(pattern_matches)
+
+orphan_html = [path for path in deployed_html if path not in tracked_html]
+stale_plot_html = [path for path in orphan_html if path.startswith("docs/plots/")]
+
+duplicate_dashboards = [
+    path
+    for path in deployed_html
+    if path != "docs/dashboard.html" and Path(path).name.startswith("dashboard")
+]
+
+errors = []
 if missing:
-    raise SystemExit('Missing published pages from manifest:\n' + '\n'.join(missing))
+    errors.append("Missing published pages from manifest:\n" + "\n".join(missing))
+if orphan_html:
+    errors.append("Untracked public entrypoints under docs/:\n" + "\n".join(orphan_html))
+if stale_plot_html:
+    errors.append("Stale plot HTML files under docs/plots/:\n" + "\n".join(stale_plot_html))
+if duplicate_dashboards:
+    errors.append(
+        "Duplicate canonical dashboard files detected:\n" + "\n".join(duplicate_dashboards)
+    )
 
-published_html = {Path(p).as_posix() for p in published}
-deployed_html = sorted(path.as_posix() for path in Path('docs').rglob('*.html'))
-orphaned = [path for path in deployed_html if path not in published_html]
-if orphaned:
-    raise SystemExit('Untracked deployed HTML pages under docs/:\n' + '\n'.join(orphaned))
+if errors:
+    raise SystemExit("\n\n".join(errors))
 
-print('stale check passed')
+print("stale check passed")

--- a/scripts/check_stale.py
+++ b/scripts/check_stale.py
@@ -2,6 +2,8 @@ import json
 from fnmatch import fnmatch
 from pathlib import Path
 
+PLOT_HTML_PREFIX = "docs/plots/"
+
 manifest = json.loads(Path("MANIFEST.json").read_text(encoding="utf-8"))
 published = manifest.get("published_pages", [])
 if not isinstance(published, list) or not published:
@@ -21,7 +23,7 @@ for pattern in published:
     tracked_html.update(pattern_matches)
 
 orphan_html = [path for path in deployed_html if path not in tracked_html]
-stale_plot_html = [path for path in orphan_html if path.startswith("docs/plots/")]
+stale_plot_html = [path for path in orphan_html if path.startswith(PLOT_HTML_PREFIX)]
 
 duplicate_dashboards = [
     path

--- a/scripts/check_stale.py
+++ b/scripts/check_stale.py
@@ -24,6 +24,7 @@ for pattern in published:
 
 orphan_html = [path for path in deployed_html if path not in tracked_html]
 stale_plot_html = [path for path in orphan_html if path.startswith(PLOT_HTML_PREFIX)]
+orphan_non_plot_html = [path for path in orphan_html if not path.startswith(PLOT_HTML_PREFIX)]
 
 duplicate_dashboards = [
     path
@@ -34,8 +35,10 @@ duplicate_dashboards = [
 errors = []
 if missing:
     errors.append("Missing published pages from manifest:\n" + "\n".join(missing))
-if orphan_html:
-    errors.append("Untracked public entrypoints under docs/:\n" + "\n".join(orphan_html))
+if orphan_non_plot_html:
+    errors.append(
+        "Untracked public entrypoints under docs/:\n" + "\n".join(orphan_non_plot_html)
+    )
 if stale_plot_html:
     errors.append("Stale plot HTML files under docs/plots/:\n" + "\n".join(stale_plot_html))
 if duplicate_dashboards:

--- a/scripts/check_stale.py
+++ b/scripts/check_stale.py
@@ -29,7 +29,7 @@ orphan_non_plot_html = [path for path in orphan_html if not path.startswith(PLOT
 duplicate_dashboards = [
     path
     for path in deployed_html
-    if path != "docs/dashboard.html" and Path(path).name.startswith("dashboard")
+    if path != "docs/dashboard.html" and Path(path).stem.startswith("dashboard")
 ]
 
 errors = []


### PR DESCRIPTION
### Motivation

- Provide a curated GitHub Pages portal as the canonical entrypoint for verified engineering outputs and plots.  
- Enforce repository policies to prevent stale outputs, ambiguous filenames, and silent replacements of canonical artifacts.  
- Automate validation and deployment via CI to ensure pages remain verified and linkable before publication.

### Description

- Add a `MANIFEST.json` describing project metadata, published pages, build rules, and promotion controls.  
- Add a Pages site under `docs/` including `index.html`, governance placeholders (`handover.html`, `verification.html`, `regression.html`, `traceability.html`, `manifest.html`) and plot placeholders under `docs/plots/`.  
- Add policy documents `BACKBONE_POLICY.md` and `GLOB_POLICY.md` that specify protected backbones, allowed globs, forbidden patterns, and required checks.  
- Add CI and Pages workflows (`.github/workflows/ci.yml` and `.github/workflows/pages.yml`) and validation scripts in `scripts/` (`check_manifest.py`, `check_globs.py`, `check_stale.py`, `check_links.py`) and a build hook invocation for `tools/losses/src/build_all.py` where present.

### Testing

- The CI workflow is configured to run `pytest -q` and the validation scripts `scripts/check_manifest.py`, `scripts/check_globs.py`, `scripts/check_stale.py`, and `scripts/check_links.py`.  
- The Pages workflow is configured to run the build step `python tools/losses/src/build_all.py` if present and then run the same validation scripts and `pytest -q` before packaging `docs/`.  
- No automated tests were executed as part of this PR run; the workflows are added and will execute these checks on push or pull request.  
- All validation scripts exit non‑zero on failures so CI will fail when required preconditions are not met.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a03166c8a1c832e850037035c07aaeb)