### PR TITLE
Align clean handover doc to use "Minimal Copy-Paste Version"

### DIFF
--- a/99_handover/CLEAN_HANDOVER_PACK.md
+++ b/99_handover/CLEAN_HANDOVER_PACK.md
@@ -4,12 +4,12 @@ Use the **clean handover pack** and avoid the rough tuple flow (that is, passing
 
 ## Recommended operator flow
 
-1. Start by pasting the **Minimal Copy-Paste Block** (see below) into CODEX.
+1. Start by pasting the **Minimal Copy-Paste Version** (see below) into CODEX.
 2. Provide the full handover pack as supporting context only if more detail is needed.
 
-## Minimal Copy-Paste Block
+## Minimal Copy-Paste Version
 
-Copy and paste the block below verbatim at the start of every new CODEX interaction to give the agent essential project context before you supply any additional files.
+Copy and paste the version below verbatim at the start of every new CODEX interaction to give the agent essential project context before you supply any additional files.
 
 ```
 ## CODEX Minimal Context — HELIUM_VCR_UHP v1.3.0
@@ -45,8 +45,8 @@ The clean **CODEX Handover Manifest Glob Pack** should include:
 - CI workflow
 - GitHub Pages workflow
 - acceptance checklist
-- Minimal Copy-Paste Block (see above)
+- Minimal Copy-Paste Version (see above)
 
 ## Selection rule
 
-**Best option:** paste the **Minimal Copy-Paste Block** into CODEX first, then add the full pack only as needed.
+**Best option:** paste the **Minimal Copy-Paste Version** into CODEX first, then add the full pack only as needed.


### PR DESCRIPTION
### Motivation
- Align the clean handover guidance wording to consistently use "Minimal Copy-Paste Version" and reinforce the recommended operator flow of pasting the minimal context first.

### Description
- Replace occurrences of "Minimal Copy-Paste Block" with "Minimal Copy-Paste Version" in `99_handover/CLEAN_HANDOVER_PACK.md`, updating the heading, operator flow, checklist item, and selection rule (1 file changed, 5 insertions, 5 deletions).

### Testing
- Documentation-only change; no automated tests were required or run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a032d842b8c832e90d0ab4ea0b9fce9)