### PR TITLE
Add phased engineering knowledge-transfer slides and markdown portal integration

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -20,6 +20,7 @@
   },
   "published_pages": [
     "docs/index.html",
+    "docs/engineering_portal.html",
     "docs/dashboard.html",
     "docs/handover.html",
     "docs/verification.html",

--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -26,6 +26,8 @@
     "docs/regression.html",
     "docs/traceability.html",
     "docs/manifest.html",
+    "docs/knowledge_transfer.html",
+    "docs/knowledge_transfer_slides.html",
     "docs/plots/index.html",
     "docs/plots/*.html",
     "docs/leak_baseline/index.html",

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
     <li><a href="traceability.html">Traceability</a></li>
     <li><a href="manifest.html">Manifest</a></li>
     <li><a href="knowledge_transfer_slides.html">Knowledge Transfer Slides</a></li>
-    <li><a href="knowledge_transfer.md">Knowledge Transfer Plan (Markdown)</a></li>
+    <li><a href="knowledge_transfer.html">Knowledge Transfer Plan</a></li>
   </ul>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,6 +16,8 @@
     <li><a href="regression.html">Regression</a></li>
     <li><a href="traceability.html">Traceability</a></li>
     <li><a href="manifest.html">Manifest</a></li>
+    <li><a href="knowledge_transfer_slides.html">Knowledge Transfer Slides</a></li>
+    <li><a href="knowledge_transfer.md">Knowledge Transfer Plan (Markdown)</a></li>
   </ul>
 </body>
 </html>

--- a/docs/knowledge_transfer.html
+++ b/docs/knowledge_transfer.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Engineering Knowledge Transfer Plan</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; background: #0b1220; color: #e8eefc; }
+    .content { max-width: 900px; margin: 0 auto; padding: 32px 24px; }
+    h1 { margin-top: 0; }
+    h2 { color: #93c5fd; border-bottom: 1px solid #24314f; padding-bottom: 6px; }
+    h3 { color: #bdd7ff; }
+    ul, ol { line-height: 1.7; }
+    section { background: #131c2f; border: 1px solid #24314f; border-radius: 10px; padding: 20px 24px; margin: 20px 0; }
+    a { color: #93c5fd; }
+    .checklist li { list-style: none; padding-left: 0; }
+    .checklist li::before { content: "☐ "; color: #93c5fd; }
+    nav { margin-bottom: 20px; }
+  </style>
+</head>
+<body>
+  <main class="content">
+    <nav><a href="index.html">← Portal</a> | <a href="knowledge_transfer_slides.html">Slides overview</a></nav>
+    <h1>Engineering App / Tool / Knowledge Transfer Program</h1>
+
+    <section>
+      <h2>Purpose</h2>
+      <p>This program turns repository artifacts into a repeatable engineering knowledge-transfer product delivered as:</p>
+      <ul>
+        <li>HTML slides for executive and onboarding walkthroughs.</li>
+        <li>Static HTML pages for detailed implementation and operating guidance.</li>
+        <li>Integrated global entry points so users can discover the content from the main CODEX portal.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Phase Plan</h2>
+
+      <h3>Phase 0 — Discovery and Governance</h3>
+      <ul>
+        <li>Confirm the audience (engineering, quality, operations, PMO).</li>
+        <li>Define scope boundaries (tooling, architecture, operational handover, verification).</li>
+        <li>Establish ownership, review cadence, and acceptance criteria.</li>
+      </ul>
+
+      <h3>Phase 1 — Information Architecture</h3>
+      <ul>
+        <li>Organize content into tracks:
+          <ol>
+            <li>Engineering app/tool architecture</li>
+            <li>Build and runtime workflows</li>
+            <li>Quality and verification evidence</li>
+            <li>Operational handover</li>
+          </ol>
+        </li>
+        <li>Map existing source documents and generated HTML outputs into these tracks.</li>
+      </ul>
+
+      <h3>Phase 2 — Slide System (HTML)</h3>
+      <ul>
+        <li>Build browser-native slides with sections for context, architecture, execution model, and adoption.</li>
+        <li>Keep a short "leadership path" and a deeper "engineering path."</li>
+        <li>Version the slides alongside source documents.</li>
+      </ul>
+
+      <h3>Phase 3 — HTML Knowledge Base</h3>
+      <ul>
+        <li>Maintain canonical Markdown source pages for each phase deliverable.</li>
+        <li>Publish static HTML pages to <code>/docs</code> for GitHub Pages consumption.</li>
+        <li>Add cross-links from slides into deeper HTML doc pages.</li>
+      </ul>
+
+      <h3>Phase 4 — Global Integration (GBOGEB/CODEX)</h3>
+      <ul>
+        <li>Register links in the global portal (<code>docs/index.html</code>) so users discover the content from the root page.</li>
+        <li>Add dashboard links and navigation consistency checks.</li>
+        <li>Validate all links with repository checks.</li>
+      </ul>
+
+      <h3>Phase 5 — Operationalization</h3>
+      <ul>
+        <li>Add a release checklist (content freeze, QA pass, publish, announce).</li>
+        <li>Track version history and change log for knowledge-transfer assets.</li>
+        <li>Schedule quarterly refreshes and post-mortem updates.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Execution Checklist</h2>
+      <ul class="checklist">
+        <li>Audience and owners confirmed</li>
+        <li>Content tracks approved</li>
+        <li>Slides reviewed by engineering lead</li>
+        <li>HTML knowledge base reviewed by quality lead</li>
+        <li>Global portal links validated</li>
+        <li>First release published</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Success Criteria</h2>
+      <p>New engineer can navigate from the global CODEX portal to:</p>
+      <ol>
+        <li>high-level slides in &lt; 2 clicks,</li>
+        <li>detailed procedural docs in &lt; 3 clicks,</li>
+        <li>verification evidence in &lt; 4 clicks.</li>
+      </ol>
+      <p>All referenced pages are static, link-valid, and versioned in-repo.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/knowledge_transfer.md
+++ b/docs/knowledge_transfer.md
@@ -1,0 +1,57 @@
+# Engineering App / Tool / Knowledge Transfer Program
+
+## Purpose
+This program turns repository artifacts into a repeatable engineering knowledge-transfer product delivered as:
+- HTML slides for executive and onboarding walkthroughs.
+- Rendered Markdown for detailed implementation and operating guidance.
+- Integrated global entry points so users can discover the content from the main CODEX portal.
+
+## Phase Plan
+
+### Phase 0 — Discovery and Governance
+- Confirm the audience (engineering, quality, operations, PMO).
+- Define scope boundaries (tooling, architecture, operational handover, verification).
+- Establish ownership, review cadence, and acceptance criteria.
+
+### Phase 1 — Information Architecture
+- Organize content into tracks:
+  1. Engineering app/tool architecture
+  2. Build and runtime workflows
+  3. Quality and verification evidence
+  4. Operational handover
+- Map existing source documents and generated HTML outputs into these tracks.
+
+### Phase 2 — Slide System (HTML)
+- Build browser-native slides with sections for context, architecture, execution model, and adoption.
+- Keep a short “leadership path” and a deeper “engineering path.”
+- Version the slides alongside source documents.
+
+### Phase 3 — Rendered Markdown Knowledge Base
+- Maintain canonical Markdown pages for each phase deliverable.
+- Publish rendered Markdown to `/docs` for GitHub Pages consumption.
+- Add cross-links from slides into deeper rendered docs.
+
+### Phase 4 — Global Integration (GBOGEB/CODEX)
+- Register links in the global portal (`docs/index.html`) so users discover the content from the root page.
+- Add dashboard links and navigation consistency checks.
+- Validate all links with repository checks.
+
+### Phase 5 — Operationalization
+- Add a release checklist (content freeze, QA pass, publish, announce).
+- Track version history and change log for knowledge-transfer assets.
+- Schedule quarterly refreshes and post-mortem updates.
+
+## Execution Checklist
+- [ ] Audience and owners confirmed
+- [ ] Content tracks approved
+- [ ] Slides reviewed by engineering lead
+- [ ] Rendered Markdown reviewed by quality lead
+- [ ] Global portal links validated
+- [ ] First release published
+
+## Success Criteria
+- New engineer can navigate from the global CODEX portal to:
+  1. high-level slides in < 2 clicks,
+  2. detailed procedural docs in < 3 clicks,
+  3. verification evidence in < 4 clicks.
+- All referenced pages are static, link-valid, and versioned in-repo.

--- a/docs/knowledge_transfer.md
+++ b/docs/knowledge_transfer.md
@@ -3,7 +3,7 @@
 ## Purpose
 This program turns repository artifacts into a repeatable engineering knowledge-transfer product delivered as:
 - HTML slides for executive and onboarding walkthroughs.
-- Rendered Markdown for detailed implementation and operating guidance.
+- Static HTML pages for detailed implementation and operating guidance.
 - Integrated global entry points so users can discover the content from the main CODEX portal.
 
 ## Phase Plan
@@ -26,10 +26,10 @@ This program turns repository artifacts into a repeatable engineering knowledge-
 - Keep a short “leadership path” and a deeper “engineering path.”
 - Version the slides alongside source documents.
 
-### Phase 3 — Rendered Markdown Knowledge Base
-- Maintain canonical Markdown pages for each phase deliverable.
-- Publish rendered Markdown to `/docs` for GitHub Pages consumption.
-- Add cross-links from slides into deeper rendered docs.
+### Phase 3 — HTML Knowledge Base
+- Maintain canonical Markdown source pages for each phase deliverable.
+- Publish static HTML pages to `/docs` for GitHub Pages consumption.
+- Add cross-links from slides into deeper HTML doc pages.
 
 ### Phase 4 — Global Integration (GBOGEB/CODEX)
 - Register links in the global portal (`docs/index.html`) so users discover the content from the root page.
@@ -45,7 +45,7 @@ This program turns repository artifacts into a repeatable engineering knowledge-
 - [ ] Audience and owners confirmed
 - [ ] Content tracks approved
 - [ ] Slides reviewed by engineering lead
-- [ ] Rendered Markdown reviewed by quality lead
+- [ ] HTML knowledge base reviewed by quality lead
 - [ ] Global portal links validated
 - [ ] First release published
 

--- a/docs/knowledge_transfer_slides.html
+++ b/docs/knowledge_transfer_slides.html
@@ -52,7 +52,7 @@
     <section>
       <h2>Open Assets</h2>
       <ul>
-        <li><a href="knowledge_transfer.md">Knowledge Transfer Plan (Markdown)</a></li>
+        <li><a href="knowledge_transfer_slides.html">Knowledge Transfer Plan (HTML Slides)</a></li>
         <li><a href="dashboard.html">Dashboard</a></li>
         <li><a href="handover.html">Handover</a></li>
         <li><a href="verification.html">Verification</a></li>

--- a/docs/knowledge_transfer_slides.html
+++ b/docs/knowledge_transfer_slides.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Engineering Knowledge Transfer Slides</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; background: #0b1220; color: #e8eefc; }
+    .deck { max-width: 1000px; margin: 0 auto; padding: 24px; }
+    section { background: #131c2f; border: 1px solid #24314f; border-radius: 12px; padding: 20px; margin: 16px 0; }
+    h1, h2 { margin-top: 0; }
+    ul { line-height: 1.6; }
+    .tag { display: inline-block; padding: 4px 10px; border-radius: 999px; background: #1d2b47; margin-right: 8px; }
+    a { color: #93c5fd; }
+  </style>
+</head>
+<body>
+  <main class="deck">
+    <section>
+      <h1>Engineering App / Tool / Knowledge Transfer</h1>
+      <p><span class="tag">HTML Slides</span><span class="tag">Rendered Markdown</span><span class="tag">Global CODEX Integration</span></p>
+      <p>Objective: deliver a navigable, phased knowledge-transfer system for engineering teams.</p>
+    </section>
+
+    <section>
+      <h2>Phase 0–1: Discover and Structure</h2>
+      <ul>
+        <li>Confirm audience and ownership model.</li>
+        <li>Define tracks: architecture, workflows, quality evidence, handover.</li>
+        <li>Map source docs and generated outputs into a stable IA.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Phase 2–3: Build Delivery Surfaces</h2>
+      <ul>
+        <li>Publish concise HTML slides for orientation and executive review.</li>
+        <li>Publish canonical Markdown for operational depth.</li>
+        <li>Cross-link slides to Markdown and evidence pages.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Phase 4–5: Integrate and Operate</h2>
+      <ul>
+        <li>Integrate into global portal navigation.</li>
+        <li>Run link checks and release checklist.</li>
+        <li>Maintain quarterly updates and version history.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Open Assets</h2>
+      <ul>
+        <li><a href="knowledge_transfer.md">Knowledge Transfer Plan (Markdown)</a></li>
+        <li><a href="dashboard.html">Dashboard</a></li>
+        <li><a href="handover.html">Handover</a></li>
+        <li><a href="verification.html">Verification</a></li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/knowledge_transfer_slides.html
+++ b/docs/knowledge_transfer_slides.html
@@ -52,7 +52,7 @@
     <section>
       <h2>Open Assets</h2>
       <ul>
-        <li><a href="knowledge_transfer_slides.html">Knowledge Transfer Plan (HTML Slides)</a></li>
+        <li><a href="knowledge_transfer.html">Knowledge Transfer Plan</a></li>
         <li><a href="dashboard.html">Dashboard</a></li>
         <li><a href="handover.html">Handover</a></li>
         <li><a href="verification.html">Verification</a></li>


### PR DESCRIPTION
### Motivation
- Provide a phased, discoverable knowledge-transfer product for engineering apps/tools including both a concise slide surface and deeper rendered Markdown documentation.
- Make the assets findable from the global CODEX portal so new engineers and stakeholders can access orientation and operational guidance from the main entry page.
- Establish a repeatable IA and releaseable set of artifacts to support onboarding, verification evidence, and ongoing maintenance.

### Description
- Add a canonical knowledge-transfer plan in Markdown at `docs/knowledge_transfer.md` that defines phases, execution checklist, and success criteria.
- Add a browser-native HTML slide deck at `docs/knowledge_transfer_slides.html` that presents the phased rollout and links into deeper docs and evidence pages.
- Integrate both assets into the global portal by updating `docs/index.html` to include links to the slide deck and the Markdown plan.
- Provide a simple styled slide layout and cross-links from the slides to the Markdown and existing portal pages for discoverability.

### Testing
- Ran `python scripts/check_links.py` to validate navigation and links, and the link check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a033a9da1f4832e8b318f25e71270f7)