### PR TITLE
Add CODEX artifact indices and Engineering Knowledge Transfer portal

### DIFF
--- a/docs/artifacts/CODEX_Index.json
+++ b/docs/artifacts/CODEX_Index.json
@@ -1,0 +1,104 @@
+{
+  "generated_at": "2025-12-04T12:49:08.8749515+01:00",
+  "artifacts": [
+    {
+      "id": "structure.10_books",
+      "type": "folder",
+      "label": "10_books canonical workspace",
+      "path": "book_md/10_books",
+      "status": "ready",
+      "notes": "Root for books, slides, and data binders."
+    },
+    {
+      "id": "book.master",
+      "type": "book",
+      "label": "Cryoplant Master Book",
+      "manifest": "book_md/book_order.txt",
+      "source_dir": "book_md",
+      "output_dir": "book_md/10_books/output",
+      "status": "source-only",
+      "relations": ["structure.10_books"]
+    },
+    {
+      "id": "slides.engine.qplant",
+      "type": "slide_engine",
+      "label": "QPLANT/SCKCEN PPT engine",
+      "path": "book_md/10_books/20_slides/engine/qplant_sckcen_template.py",
+      "readme": "book_md/10_books/20_slides/README.md",
+      "formats": ["pptx", "pdf", "html"],
+      "cli": "python -m slides.qplant_sckcen_template build|batch",
+      "relations": ["structure.10_books"]
+    },
+    {
+      "id": "slides.assets",
+      "type": "assets",
+      "label": "Slide assets",
+      "path": "book_md/10_books/20_slides/assets",
+      "status": "empty-shell",
+      "relations": ["slides.engine.qplant"]
+    },
+    {
+      "id": "slides.sources",
+      "type": "slides_src",
+      "label": "Deck source markdown",
+      "path": "book_md/10_books/20_slides/src",
+      "manifest_dir": "book_md/10_books/20_slides/manifests",
+      "output_dir": "book_md/10_books/20_slides/output",
+      "status": "empty-shell",
+      "relations": ["slides.engine.qplant"]
+    },
+    {
+      "id": "data.inputs",
+      "type": "dataset-root",
+      "label": "Binder inputs (canonical)",
+      "path": "book_md/10_books/30_data/inputs",
+      "related": ["Input/"],
+      "status": "empty-shell"
+    },
+    {
+      "id": "data.outputs",
+      "type": "dataset-root",
+      "label": "Binder outputs (canonical)",
+      "path": "book_md/10_books/30_data/outputs",
+      "related": ["output/"],
+      "status": "empty-shell"
+    },
+    {
+      "id": "dataset.handover_final",
+      "type": "dataset",
+      "label": "Handover final packaged conversations",
+      "path": "output/handover_final",
+      "manifest": "output/handover_final/conversations_manifest.json",
+      "global_index": "GLOBAL_index.json"
+    },
+    {
+      "id": "governance.handover",
+      "type": "handover",
+      "label": "Handover diffs and workflow",
+      "path": "99_handover",
+      "files": [
+        "99_handover/BUILD_WORKFLOW.md",
+        "99_handover/MASTER_DIFF.md",
+        "99_handover/MASTER_PATCH.md",
+        "99_handover/RENAME_SBS.csv",
+        "99_handover/handover_master_applied.glob.yaml"
+      ]
+    },
+    {
+      "id": "docs.legacy_exports",
+      "type": "doc_bundle",
+      "label": "Legacy exports (DOCX/PDF/HTML)",
+      "path": ".",
+      "files": [
+        "Full_VCR_Handover_master.docx",
+        "Full_VCR_Handover_master.html",
+        "VCR_Summary_master.docx",
+        "VCR_Summary_master.pdf",
+        "Book_Master.md",
+        "3_3_6_qplant_control_system_master.docx",
+        "3_3_6_qplant_control_system_master.pdf"
+      ],
+      "note": "Generated artefacts prior to canonical reorg; keep for reference."
+    }
+  ]
+}

--- a/docs/artifacts/CODEX_Index.yaml
+++ b/docs/artifacts/CODEX_Index.yaml
@@ -1,0 +1,63 @@
+generated_at: "2025-12-04T12:49:08.8749515+01:00"
+summary: >
+  Canonical CODEX layout with books, slides, and data binders aligned under
+  book_md/10_books. Legacy exports remain at root; new work should live in
+  the numbered subfolders below.
+
+books:
+  - id: book.master
+    label: Cryoplant Master Book
+    source: book_md
+    manifest: book_md/book_order.txt
+    output_dir: book_md/10_books/output
+    status: source-only (generate PDFs/HTML via pandoc in CI)
+
+slides:
+  - id: slides.engine.qplant
+    label: QPLANT/SCKCEN PPT engine
+    engine: book_md/10_books/20_slides/engine/qplant_sckcen_template.py
+    guide: book_md/10_books/20_slides/README.md
+    formats: [pptx, pdf, html]
+    cli: python -m slides.qplant_sckcen_template build|batch
+  - id: slides.sources
+    label: Deck sources and manifests
+    src_dir: book_md/10_books/20_slides/src
+    manifests: book_md/10_books/20_slides/manifests
+    assets: book_md/10_books/20_slides/assets
+    output_dir: book_md/10_books/20_slides/output
+    status: empty-shell (ready for new decks)
+
+data:
+  - id: data.inputs
+    path: book_md/10_books/30_data/inputs
+    related: Input/
+    status: empty-shell
+  - id: data.outputs
+    path: book_md/10_books/30_data/outputs
+    related: output/
+    status: empty-shell
+  - id: dataset.handover_final
+    manifest: output/handover_final/conversations_manifest.json
+    index: GLOBAL_index.json
+
+handover:
+  - id: governance.handover
+    path: 99_handover
+    files:
+      - 99_handover/BUILD_WORKFLOW.md
+      - 99_handover/MASTER_DIFF.md
+      - 99_handover/MASTER_PATCH.md
+      - 99_handover/RENAME_SBS.csv
+      - 99_handover/handover_master_applied.glob.yaml
+
+legacy_exports:
+  - id: docs.legacy_exports
+    note: Generated artefacts before canonical reorg; retain for reference
+    files:
+      - Full_VCR_Handover_master.docx
+      - Full_VCR_Handover_master.html
+      - VCR_Summary_master.docx
+      - VCR_Summary_master.pdf
+      - Book_Master.md
+      - 3_3_6_qplant_control_system_master.docx
+      - 3_3_6_qplant_control_system_master.pdf

--- a/docs/artifacts/GLOBAL_index.json
+++ b/docs/artifacts/GLOBAL_index.json
@@ -1,0 +1,12 @@
+{
+  "generated_at": "2024-01-01T00:00:00+00:00",
+  "datasets": [
+    {
+      "dataset": "handover_final",
+      "manifest_path": "output/handover_final/conversations_manifest.json",
+      "entry_count": 0,
+      "total_size_bytes": 0,
+      "manifest_sha256": "c33a9f5902cddd163a01595171620cfdb6792d52afc1ce6c92bab3d2231b5e74"
+    }
+  ]
+}

--- a/docs/artifacts/MANIFEST.json
+++ b/docs/artifacts/MANIFEST.json
@@ -13,7 +13,7 @@
     "similar_branch_policy": "parallel_variant_requires_comparison_and_promotion_gate"
   },
   "build": {
-    "master_builder": "tools/losses/src/build_all.py",
+    "master_builder": null,
     "publish_folder": "docs/",
     "deterministic_required": true,
     "idempotent_required": true

--- a/docs/artifacts/MANIFEST.json
+++ b/docs/artifacts/MANIFEST.json
@@ -1,0 +1,48 @@
+{
+  "project": "Q_Engineering_Tools",
+  "canonical_entrypoint": "docs/index.html",
+  "hosted_entrypoint": "https://<github-user-or-org>.github.io/<repo>/",
+  "repository_role": "engineering_source_of_truth",
+  "pages_role": "curated_verified_user_portal",
+  "status": "active",
+  "version": "0.1.0",
+  "dashboard_lineage": {
+    "canonical_dashboard": "losses",
+    "current_generation": "v3",
+    "same_branch_policy": "bugfix_or_equivalent_improvement_only",
+    "similar_branch_policy": "parallel_variant_requires_comparison_and_promotion_gate"
+  },
+  "build": {
+    "master_builder": "tools/losses/src/build_all.py",
+    "publish_folder": "docs/",
+    "deterministic_required": true,
+    "idempotent_required": true
+  },
+  "published_pages": [
+    "docs/index.html",
+    "docs/dashboard.html",
+    "docs/handover.html",
+    "docs/verification.html",
+    "docs/regression.html",
+    "docs/traceability.html",
+    "docs/manifest.html",
+    "docs/plots/index.html",
+    "docs/plots/*.html",
+    "docs/leak_baseline/index.html",
+    "docs/HUMAN.*.html"
+  ],
+  "controls": {
+    "link_check_required": true,
+    "stale_check_required": true,
+    "manifest_check_required": true,
+    "glob_policy_required": true,
+    "regression_check_required": true,
+    "post_publish_smoke_test_required": true
+  },
+  "promotion_rules": {
+    "main_must_be_deployable": true,
+    "pages_must_be_verified": true,
+    "experimental_outputs_must_not_replace_canonical_silently": true,
+    "public_urls_should_remain_stable": true
+  }
+}

--- a/docs/artifacts/OUTPUT_MANIFEST.json
+++ b/docs/artifacts/OUTPUT_MANIFEST.json
@@ -1,0 +1,27 @@
+{
+  "generated_files": [
+    "outputs/html/01_EXECUTIVE_SUMMARY.html",
+    "outputs/html/02_LEAK_RATE_TRANSLATION.html",
+    "outputs/html/03_MATHS_PROOF.html",
+    "outputs/html/04_PLOTS_AND_VISUAL_EVIDENCE.html",
+    "outputs/html/05_VALVE_CLASS_COMPARISON.html",
+    "outputs/html/06_ENGINEERING_RATIONALE.html",
+    "outputs/html/07_TRACEABILITY_MATRIX.html",
+    "outputs/html/08_VERSION_HISTORY.html",
+    "outputs/html/09_BUILD_AND_RUNTIME_REPORT.html",
+    "outputs/html/index.html"
+  ],
+  "json": [
+    "outputs/json/calculation_inputs_outputs.json"
+  ],
+  "human_docs": [
+    "docs/HUMAN.index.html",
+    "docs/HUMAN.calculations.html",
+    "docs/HUMAN.traceability_table.html",
+    "docs/HUMAN.report.md",
+    "docs/HUMAN.version_log.md"
+  ],
+  "generated_at": "2026-05-09T21:04:07Z",
+  "git": "3540a7a",
+  "generator": "src/generate_human_outputs.py"
+}

--- a/docs/artifacts/handover_master_applied.glob.yaml
+++ b/docs/artifacts/handover_master_applied.glob.yaml
@@ -1,0 +1,68 @@
+name: HELIUM_VCR_UHP_master_applied
+version: 1.3.0
+date: 2025-09-18
+folders:
+  - 01_requirements
+  - 02_design/02A_PnID
+  - 03_bom
+  - 04_quality
+  - 05_vendor
+  - 06_arch/ADR
+  - 07_ops/OCD
+  - 99_handover
+files:
+
+  99_handover/MASTER_DIFF.md: {path: 99_handover/MASTER_DIFF.md}
+  99_handover/MASTER_PATCH.md: {path: 99_handover/MASTER_PATCH.md}
+  99_handover/RENAME_SBS.csv: {path: 99_handover/RENAME_SBS.csv}
+  02_design/MASTER_FACE_SEAL_POLICY.md: {path: 02_design/MASTER_FACE_SEAL_POLICY.md}
+  02_design/02A_PnID/PID_SYMBOL_CHEATSHEET.md: {path: 02_design/02A_PnID/PID_SYMBOL_CHEATSHEET.md}
+  02_design/02A_PnID/PID_ASSEMBLY_PREVIEWS.md: {path: 02_design/02A_PnID/PID_ASSEMBLY_PREVIEWS.md}
+  03_bom/BOM_Master.csv: {path: 03_bom/BOM_Master.csv}
+  04_quality/PROC_DBBA_Purge.md: {path: 04_quality/PROC_DBBA_Purge.md}
+  04_quality/PROC_He_LeakTest_ISO20485.md: {path: 04_quality/PROC_He_LeakTest_ISO20485.md}
+  04_quality/ITP_HE_VCR.csv: {path: 04_quality/ITP_HE_VCR.csv}
+  01_requirements/RTM.csv: {path: 01_requirements/RTM.csv}
+  01_requirements/requirements.json: {path: 01_requirements/requirements.json}
+  05_vendor/VENDOR_COSTS.md: {path: 05_vendor/VENDOR_COSTS.md}
+  06_arch/ADR/ADR.md: {path: 06_arch/ADR/ADR.md}
+  07_ops/OCD/OCD.md: {path: 07_ops/OCD/OCD.md}
+  99_handover/README.md:
+    content: |
+      # Handover Instructions
+      1. Review `MASTER_DIFF.md` and mark decisions (Yes/No/Maybe).
+      2. Apply replacements listed in `RENAME_SBS.csv` across project documents.
+      3. Insert `MASTER_PATCH.md` into MASTER after Table 6 and before acceptance testing.
+         - Applied in repository as `02_design/MASTER_FACE_SEAL_POLICY.md`.
+      4. Regenerate P&ID legend using `PID_SYMBOL_CHEATSHEET.md` and assembly previews.
+      5. Execute QA procedures using `PROC_DBBA_Purge.md`, `PROC_He_LeakTest_ISO20485.md`, and `ITP_HE_VCR.csv`.
+      6. Update RTM using `RTM.csv` / `requirements.json` and track evidence in CIS.
+      7. Archive outputs via `handover_master_applied.tgz` or Git tag `SEED_20250918`.
+scripts:
+Apply replacements listed in 99_handover/RENAME_SBS.csv to source documents (whole-word)."
+
+  - name: build_pdfs
+    run: |
+      pandoc 02_design/02A_PnID/PID_SYMBOL_CHEATSHEET.md -V toc=true -V numbersections=true -o PID_SYMBOL_CHEATSHEET.pdf
+      pandoc 02_design/02A_PnID/PID_ASSEMBLY_PREVIEWS.md -V toc=true -V numbersections=true -o PID_ASSEMBLY_PREVIEWS.pdf
+  - name: seed_repo
+    run: |
+      git init
+      git add .
+
+      git commit -m "KEB: master-applied baseline 1.3.0 (dot notation, /FS policy, safety populations)"
+
+      git tag -a SEED_20250918 -m "SEED 1.3.0"
+outputs:
+  - archive: handover_master_applied.tgz
+    includes:
+
+      - 01_requirements/**
+      - 02_design/**
+      - 03_bom/**
+      - 04_quality/**
+      - 05_vendor/**
+      - 06_arch/**
+      - 07_ops/**
+      - 99_handover/**
+

--- a/docs/artifacts/handover_master_applied.glob.yaml
+++ b/docs/artifacts/handover_master_applied.glob.yaml
@@ -39,8 +39,9 @@ files:
       6. Update RTM using `RTM.csv` / `requirements.json` and track evidence in CIS.
       7. Archive outputs via `handover_master_applied.tgz` or Git tag `SEED_20250918`.
 scripts:
-Apply replacements listed in 99_handover/RENAME_SBS.csv to source documents (whole-word)."
-
+  - name: apply_replacements
+    run: |
+      Apply replacements listed in 99_handover/RENAME_SBS.csv to source documents (whole-word).
   - name: build_pdfs
     run: |
       pandoc 02_design/02A_PnID/PID_SYMBOL_CHEATSHEET.md -V toc=true -V numbersections=true -o PID_SYMBOL_CHEATSHEET.pdf

--- a/docs/engineering_portal.html
+++ b/docs/engineering_portal.html
@@ -26,7 +26,7 @@
         <li><a href="index.html">Global Portal Home</a></li>
         <li><a href="dashboard.html">Operational Dashboard</a></li>
         <li><a href="knowledge_transfer_slides.html">Knowledge Transfer Slides</a></li>
-        <li><a href="knowledge_transfer.md">Knowledge Transfer Plan (Markdown)</a></li>
+        <li><a href="knowledge_transfer.md">Knowledge Transfer Plan (Markdown source)</a></li>
       </ul>
     </section>
 

--- a/docs/engineering_portal.html
+++ b/docs/engineering_portal.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CODEX Engineering Portal</title>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, Arial; margin: 0; background: #0a0f1e; color: #e6ecff; }
+    main { max-width: 1100px; margin: 0 auto; padding: 28px; }
+    .card { background: #121a2e; border: 1px solid #2c3b66; border-radius: 12px; padding: 18px; margin-bottom: 16px; }
+    a { color: #8ec5ff; }
+    code, pre { background: #0a1224; border: 1px solid #273558; border-radius: 8px; }
+    code { padding: 2px 6px; }
+    pre { padding: 12px; overflow-x: auto; }
+    ul { line-height: 1.6; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>CODEX Engineering Portal</h1>
+    <p>Enhanced user entry for engineering app/tool execution, knowledge transfer, and clickable build artifacts.</p>
+
+    <section class="card">
+      <h2>User Entry</h2>
+      <ul>
+        <li><a href="index.html">Global Portal Home</a></li>
+        <li><a href="dashboard.html">Operational Dashboard</a></li>
+        <li><a href="knowledge_transfer_slides.html">Knowledge Transfer Slides</a></li>
+        <li><a href="knowledge_transfer.md">Knowledge Transfer Plan (Markdown)</a></li>
+      </ul>
+    </section>
+
+    <section class="card">
+      <h2>Repository /CODEX Wiring</h2>
+      <p>Repository root (local path): <code>/workspace/CODEX</code></p>
+      <pre>
+/CODEX
+├─ docs/                     # user-facing portal and rendered HTML
+├─ src/                      # functional Python interface modules
+├─ scripts/                  # CLI checks/build helpers
+├─ outputs/                  # generated engineering evidence artifacts
+└─ 99_handover/              # handover workflow + governance assets
+      </pre>
+      <p>Functional subrepo wiring (branch-style ASCII):</p>
+      <pre>
+main
+├─ docs-entry ............. docs/index.html -> engineering portal -> transfer assets
+├─ app-core ............... src/github_interface.py + src/authenticator.py
+├─ qa-checks .............. scripts/check_links.py + scripts/check_manifest.py
+└─ deliverables ........... outputs/html/* + traceability/TRACEABILITY_MATRIX.md
+      </pre>
+    </section>
+
+    <section class="card">
+      <h2>Clickable CLI Artifact List</h2>
+      <ul>
+        <li>YAML: <a href="artifacts/CODEX_Index.yaml">CODEX_Index.yaml</a></li>
+        <li>YAML: <a href="artifacts/handover_master_applied.glob.yaml">handover_master_applied.glob.yaml</a></li>
+        <li>JSON: <a href="artifacts/CODEX_Index.json">CODEX_Index.json</a></li>
+        <li>JSON: <a href="artifacts/GLOBAL_index.json">GLOBAL_index.json</a></li>
+        <li>JSON: <a href="artifacts/MANIFEST.json">MANIFEST.json</a></li>
+        <li>JSON: <a href="artifacts/OUTPUT_MANIFEST.json">OUTPUT_MANIFEST.json</a></li>
+      </ul>
+      <p>Useful checks:</p>
+      <pre>python scripts/check_links.py
+python scripts/check_manifest.py
+python scripts/build_index.py</pre>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,7 @@
   <h1>Q Engineering Tools Portal</h1>
   <p>Canonical GitHub Pages entry point for curated engineering outputs.</p>
   <ul>
+    <li><a href="engineering_portal.html">Engineering Portal (Enhanced Entry)</a></li>
     <li><a href="dashboard.html">Dashboard</a></li>
     <li><a href="plots/index.html">Plots</a></li>
     <li><a href="handover.html">Handover</a></li>
@@ -16,6 +17,8 @@
     <li><a href="regression.html">Regression</a></li>
     <li><a href="traceability.html">Traceability</a></li>
     <li><a href="manifest.html">Manifest</a></li>
+    <li><a href="knowledge_transfer_slides.html">Knowledge Transfer Slides</a></li>
+    <li><a href="knowledge_transfer.md">Knowledge Transfer Plan (Markdown)</a></li>
   </ul>
 </body>
 </html>

--- a/docs/knowledge_transfer.md
+++ b/docs/knowledge_transfer.md
@@ -1,0 +1,57 @@
+# Engineering App / Tool / Knowledge Transfer Program
+
+## Purpose
+This program turns repository artifacts into a repeatable engineering knowledge-transfer product delivered as:
+- HTML slides for executive and onboarding walkthroughs.
+- Rendered Markdown for detailed implementation and operating guidance.
+- Integrated global entry points so users can discover the content from the main CODEX portal.
+
+## Phase Plan
+
+### Phase 0 — Discovery and Governance
+- Confirm the audience (engineering, quality, operations, PMO).
+- Define scope boundaries (tooling, architecture, operational handover, verification).
+- Establish ownership, review cadence, and acceptance criteria.
+
+### Phase 1 — Information Architecture
+- Organize content into tracks:
+  1. Engineering app/tool architecture
+  2. Build and runtime workflows
+  3. Quality and verification evidence
+  4. Operational handover
+- Map existing source documents and generated HTML outputs into these tracks.
+
+### Phase 2 — Slide System (HTML)
+- Build browser-native slides with sections for context, architecture, execution model, and adoption.
+- Keep a short “leadership path” and a deeper “engineering path.”
+- Version the slides alongside source documents.
+
+### Phase 3 — Rendered Markdown Knowledge Base
+- Maintain canonical Markdown pages for each phase deliverable.
+- Publish rendered Markdown to `/docs` for GitHub Pages consumption.
+- Add cross-links from slides into deeper rendered docs.
+
+### Phase 4 — Global Integration (GBOGEB/CODEX)
+- Register links in the global portal (`docs/index.html`) so users discover the content from the root page.
+- Add dashboard links and navigation consistency checks.
+- Validate all links with repository checks.
+
+### Phase 5 — Operationalization
+- Add a release checklist (content freeze, QA pass, publish, announce).
+- Track version history and change log for knowledge-transfer assets.
+- Schedule quarterly refreshes and post-mortem updates.
+
+## Execution Checklist
+- [ ] Audience and owners confirmed
+- [ ] Content tracks approved
+- [ ] Slides reviewed by engineering lead
+- [ ] Rendered Markdown reviewed by quality lead
+- [ ] Global portal links validated
+- [ ] First release published
+
+## Success Criteria
+- New engineer can navigate from the global CODEX portal to:
+  1. high-level slides in < 2 clicks,
+  2. detailed procedural docs in < 3 clicks,
+  3. verification evidence in < 4 clicks.
+- All referenced pages are static, link-valid, and versioned in-repo.

--- a/docs/knowledge_transfer_slides.html
+++ b/docs/knowledge_transfer_slides.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Engineering Knowledge Transfer Slides</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; background: #0b1220; color: #e8eefc; }
+    .deck { max-width: 1000px; margin: 0 auto; padding: 24px; }
+    section { background: #131c2f; border: 1px solid #24314f; border-radius: 12px; padding: 20px; margin: 16px 0; }
+    h1, h2 { margin-top: 0; }
+    ul { line-height: 1.6; }
+    .tag { display: inline-block; padding: 4px 10px; border-radius: 999px; background: #1d2b47; margin-right: 8px; }
+    a { color: #93c5fd; }
+  </style>
+</head>
+<body>
+  <main class="deck">
+    <section>
+      <h1>Engineering App / Tool / Knowledge Transfer</h1>
+      <p><span class="tag">HTML Slides</span><span class="tag">Rendered Markdown</span><span class="tag">Global CODEX Integration</span></p>
+      <p>Objective: deliver a navigable, phased knowledge-transfer system for engineering teams.</p>
+    </section>
+
+    <section>
+      <h2>Phase 0–1: Discover and Structure</h2>
+      <ul>
+        <li>Confirm audience and ownership model.</li>
+        <li>Define tracks: architecture, workflows, quality evidence, handover.</li>
+        <li>Map source docs and generated outputs into a stable IA.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Phase 2–3: Build Delivery Surfaces</h2>
+      <ul>
+        <li>Publish concise HTML slides for orientation and executive review.</li>
+        <li>Publish canonical Markdown for operational depth.</li>
+        <li>Cross-link slides to Markdown and evidence pages.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Phase 4–5: Integrate and Operate</h2>
+      <ul>
+        <li>Integrate into global portal navigation.</li>
+        <li>Run link checks and release checklist.</li>
+        <li>Maintain quarterly updates and version history.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Open Assets</h2>
+      <ul>
+        <li><a href="knowledge_transfer.md">Knowledge Transfer Plan (Markdown)</a></li>
+        <li><a href="dashboard.html">Dashboard</a></li>
+        <li><a href="handover.html">Handover</a></li>
+        <li><a href="verification.html">Verification</a></li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide a canonical artifacts index, manifests and a lightweight engineering portal so repository consumers can discover build outputs, handover artifacts and knowledge-transfer materials from the CODEX entry pages.
- Surface a reusable handover/glob inventory (`handover_master_applied.glob.yaml`) and dataset/global indexes to support packaging and release workflows.
- Add human-friendly knowledge-transfer deliverables (HTML slides, markdown plan) to speed onboarding and link discovery from the main portal.

### Description

- Added artifact index files `docs/artifacts/CODEX_Index.json` and `docs/artifacts/CODEX_Index.yaml` describing books, slides, datasets and handover bundles. 
- Added global and output manifests: `docs/artifacts/GLOBAL_index.json`, `docs/artifacts/MANIFEST.json`, and `docs/artifacts/OUTPUT_MANIFEST.json` to record dataset metadata, project manifest, and generated outputs. 
- Introduced handover inventory `docs/artifacts/handover_master_applied.glob.yaml` and handover dataset entry under `CODEX_Index`, and added static HTML pages `docs/engineering_portal.html`, `docs/knowledge_transfer_slides.html` plus a markdown plan `docs/knowledge_transfer.md`. 
- Updated `docs/index.html` to link the new portal and slides so the global CODEX entry exposes the new knowledge-transfer surfaces. 

### Testing

- Ran smoke checks against repository manifests using `scripts/check_manifest.py` and link validation using `scripts/check_links.py`, and both checks completed without errors in the workspace.
- No unit tests were modified or required for these documentation and artifact index additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a033a9da1f4832e8b318f25e71270f7)