### PR TITLE
Ignore local GISTAU canonical binaries and add master source manifest and checksum template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,10 @@ output/**/*.html
 
 # Global indexes produced at runtime
 GLOBAL_index.generated.json
+
+# GISTAU local-only canonical binaries
+GISTAU/sources/master/*.docx
+GISTAU/sources/master/*.pdf
+!GISTAU/sources/master/source_manifest.yaml
+!GISTAU/sources/master/checksums.sha256
+GISTAU/derived/tmp/

--- a/GISTAU/sources/master/checksums.sha256
+++ b/GISTAU/sources/master/checksums.sha256
@@ -1,0 +1,3 @@
+# Populate once local canonical binaries are copied into sources/master/
+# Example:
+# sha256sum sources/master/master.docx sources/master/master.pdf sources/master/Chapter15_Gitua_tools.pdf > sources/master/checksums.sha256

--- a/GISTAU/sources/master/checksums.sha256
+++ b/GISTAU/sources/master/checksums.sha256
@@ -1,3 +1,5 @@
-# Populate once local canonical binaries are copied into sources/master/
-# Example:
+# Populate once local canonical binaries are copied into GISTAU/sources/master/
+# Run from the repository root:
+# sha256sum GISTAU/sources/master/master.docx GISTAU/sources/master/master.pdf GISTAU/sources/master/Chapter15_Gitua_tools.pdf > GISTAU/sources/master/checksums.sha256
+# Or, if running from within the GISTAU/ directory:
 # sha256sum sources/master/master.docx sources/master/master.pdf sources/master/Chapter15_Gitua_tools.pdf > sources/master/checksums.sha256

--- a/GISTAU/sources/master/source_manifest.yaml
+++ b/GISTAU/sources/master/source_manifest.yaml
@@ -5,10 +5,10 @@ source_identity:
   pdf_original_name: "QPS_Contract_mirror_DOCX.pdf"
   reference_original_name: "Chapter15_Gitua_tools.pdf"
 source_pair:
-  docx: sources/master/master.docx
-  pdf: sources/master/master.pdf
+  docx: GISTAU/sources/master/master.docx
+  pdf: GISTAU/sources/master/master.pdf
 references:
-  - sources/master/Chapter15_Gitua_tools.pdf
+  - GISTAU/sources/master/Chapter15_Gitua_tools.pdf
 role:
   docx: editable canonical source
   pdf: rendered mirror for parsing validation

--- a/GISTAU/sources/master/source_manifest.yaml
+++ b/GISTAU/sources/master/source_manifest.yaml
@@ -1,0 +1,21 @@
+canonical_id: master
+title: QPS Addendum II Master
+source_identity:
+  docx_original_name: "QPS (Addendum II) draft after approval.docx"
+  pdf_original_name: "QPS_Contract_mirror_DOCX.pdf"
+  reference_original_name: "Chapter15_Gitua_tools.pdf"
+source_pair:
+  docx: sources/master/master.docx
+  pdf: sources/master/master.pdf
+references:
+  - sources/master/Chapter15_Gitua_tools.pdf
+role:
+  docx: editable canonical source
+  pdf: rendered mirror for parsing validation
+  reference: thermodynamic-tool reference
+derived_outputs:
+  - derived/markdown
+  - derived/html
+  - derived/index
+big_binary_policy: local_first
+github_policy: push only diffs, patches, manifests, extracted markdown/html unless first-pass archive is approved


### PR DESCRIPTION
### Motivation

- Provide local-only handling for GISTAU canonical binary sources and include metadata and checksum templates to support downstream derivation and verification.
- Prevent large canonical binaries from being accidentally committed while still allowing manifest and checksum artifacts to be versioned.
- Capture the `master` canonical source identity, roles, references, derived outputs, and repository policies for deterministic processing.

### Description

- Update `.gitignore` to ignore `GISTAU/sources/master/*.docx` and `GISTAU/sources/master/*.pdf` while explicitly allowing `GISTAU/sources/master/source_manifest.yaml` and `GISTAU/sources/master/checksums.sha256`, and to ignore `GISTAU/derived/tmp/`.
- Add `GISTAU/sources/master/source_manifest.yaml` containing `canonical_id`, title, `source_identity`, `source_pair`, `references`, `role` mappings, `derived_outputs`, `big_binary_policy`, and `github_policy` settings.
- Add `GISTAU/sources/master/checksums.sha256` as a template with instructions and an example `sha256sum` invocation for populating checksums for local canonical binaries.

### Testing

- No automated tests were applicable to these repository metadata and ignore-rule changes.
- No CI or unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a05a50eaa9c832ebcad4afe51037862)