### PR TITLE
Add QCELL v0.6.0 governance/reset package baseline

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -32,7 +32,8 @@
     "docs/plots/index.html",
     "docs/plots/*.html",
     "docs/leak_baseline/index.html",
-    "docs/HUMAN.*.html"
+    "docs/HUMAN.*.html",
+    "docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.html"
   ],
   "controls": {
     "link_check_required": true,

--- a/docs/qcell_svg_rebuild_v0_6_0/CHANGELOG.md
+++ b/docs/qcell_svg_rebuild_v0_6_0/CHANGELOG.md
@@ -1,0 +1,14 @@
+# CHANGELOG
+
+## v0.6.0
+- Froze the rebuild baseline.
+- Stopped PPT-first workflow due to drift/degradation.
+- Preserved v0.1 to v0.5 artefacts as lineage.
+- Defined SVG/HTML/YAML/Markdown as the primary artefact chain.
+- Added recursive tuple update protocol.
+- Added phased rebuild plan and progress tracker.
+- Added explicit instruction: do not break existing artefacts.
+
+## Next: v0.7.0
+- Build SVG grammar/style proof.
+- Focus only on boundaries, arrows, pressure/temperature colour scales, and card layout.

--- a/docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.html
+++ b/docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.html
@@ -1,42 +1,68 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8"><title>QCELL SVG Rebuild Governance v0.6.0</title></head><body><pre># QCELL SVG Rebuild Governance Plan v0.6.0
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>QCELL SVG Rebuild Governance v0.6.0</title>
+</head>
+<body>
+  <h1>QCELL SVG Rebuild Governance Plan v0.6.0</h1>
 
-## Decision: stop PPT-first drift
+  <h2>Decision: stop PPT-first drift</h2>
 
-The PPT deck is now a **reference source**, not the production artefact. The rebuild starts from **versioned SVG/HTML + SSOT YAML + rendered Markdown**. Optional PPT/PDF exports come only after the SVG model is stable.
+  <p>
+    The PPT deck is now a <strong>reference source</strong>, not the production artefact.
+    The rebuild starts from <strong>versioned SVG/HTML + SSOT YAML + rendered Markdown</strong>.
+    Optional PPT/PDF exports come only after the SVG model is stable.
+  </p>
 
-## Source basis
+  <h2>Source basis</h2>
 
-- Uploaded QCELL staged concept deck: nested 2K mass, 50K shield, MLI, vacuum, ambient boundary, radiation and conduction sources.
-- Raw conversation and tuple file: temperature colour rules, pressure mode, A/B and D/E circuits, parasitic-load semantics, GitHub-hosted HTML requirement.
-- Existing v0.3.0 HTML/SVG: keep interaction, YAML panel, pressure/temperature toggle, named lines, boundaries, and changelog structure.
-- Existing v0.4.1 artefact: preserve the improved narrative and SSOT idea.
-- v0.5.0 narrative: keep only as storyboard seed.
+  <ul>
+    <li>Uploaded QCELL staged concept deck: nested 2K mass, 50K shield, MLI, vacuum, ambient boundary, radiation and conduction sources.</li>
+    <li>Raw conversation and tuple file: temperature colour rules, pressure mode, A/B and D/E circuits, parasitic-load semantics, GitHub-hosted HTML requirement.</li>
+    <li>Existing v0.3.0 HTML/SVG: keep interaction, YAML panel, pressure/temperature toggle, named lines, boundaries, and changelog structure.</li>
+    <li>Existing v0.4.1 artefact: preserve the improved narrative and SSOT idea.</li>
+    <li>v0.5.0 narrative: keep only as storyboard seed.</li>
+  </ul>
 
-## Rebuild principles
+  <h2>Rebuild principles</h2>
 
-1. Do not break existing versions.
-2. SVG is the drawing source; HTML is the hosted interactive wrapper.
-3. YAML is the SSOT for labels, values, colours, equations, views, and lineage.
-4. Re-running with the same YAML must produce the same SVG/HTML.
-5. Each revision updates tuple inventory, changelog, lineage, review checklist, SVG, HTML, and Markdown.
-6. User steering happens at phase gates on small SVG/HTML increments.
+  <ol>
+    <li>Do not break existing versions.</li>
+    <li>SVG is the drawing source; HTML is the hosted interactive wrapper.</li>
+    <li>YAML is the SSOT for labels, values, colours, equations, views, and lineage.</li>
+    <li>Re-running with the same YAML must produce the same SVG/HTML.</li>
+    <li>Each revision updates tuple inventory, changelog, lineage, review checklist, SVG, HTML, and Markdown.</li>
+    <li>User steering happens at phase gates on small SVG/HTML increments.</li>
+  </ol>
 
-## Master tuple set
+  <h2>Master tuple set</h2>
 
-| Tuple | Domain | Meaning | Status |
-|---|---|---|---|
-| T-001 | Mass | 2K_mass is the protected liquid-helium core / JT black-box region | KEEP |
-| T-002 | Barrier | White annulus is vacuum barrier | KEEP |
-| T-003 | Shield | 50K thermal shield protects the 2K mass | KEEP |
-| T-004 | MLI | Blue/orange membrane indicates MLI + shield layer | KEEP |
-| T-005 | Ambient | Outer boundary is 293.15 K nominal / 300 K design | KEEP |
-| T-006 | Circuit | A = 2K supply, supercritical He, 4.5 K, 3 bar | KEEP |
-| T-007 | Circuit | B = 2K return, 2–4 K, 26–31 mbar | KEEP |
-| T-008 | Circuit | D = shield supply, 30–40 K, 12–13 bar | KEEP |
-| T-009 | Circuit | E = shield return, 50–60 K, about 20 K rise | KEEP |
-| T-010 | Colour | Temperature determines colour; 2, 4, 30, 50, 60, 77 K and separate 77–300 K scale | KEEP |
-| T-011 | Pressure | Low pressure = 27 mbar to 1.2 bar; high pressure = 1.2 bar to 15 bar | NEW |
-| T-012 | Heat flow | Nominal heat flow is high temperature to low temperature | KEEP |
+  <table>
+    <thead>
+      <tr>
+        <th>Tuple</th>
+        <th>Domain</th>
+        <th>Meaning</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>T-001</td><td>Mass</td><td>2K_mass is the protected liquid-helium core / JT black-box region</td><td>KEEP</td></tr>
+      <tr><td>T-002</td><td>Barrier</td><td>White annulus is vacuum barrier</td><td>KEEP</td></tr>
+      <tr><td>T-003</td><td>Shield</td><td>50K thermal shield protects the 2K mass</td><td>KEEP</td></tr>
+      <tr><td>T-004</td><td>MLI</td><td>Blue/orange membrane indicates MLI + shield layer</td><td>KEEP</td></tr>
+      <tr><td>T-005</td><td>Ambient</td><td>Outer boundary is 293.15 K nominal / 300 K design</td><td>KEEP</td></tr>
+      <tr><td>T-006</td><td>Circuit</td><td>A = 2K supply, supercritical He, 4.5 K, 3 bar</td><td>KEEP</td></tr>
+      <tr><td>T-007</td><td>Circuit</td><td>B = 2K return, 2–4 K, 26–31 mbar</td><td>KEEP</td></tr>
+      <tr><td>T-008</td><td>Circuit</td><td>D = shield supply, 30–40 K, 12–13 bar</td><td>KEEP</td></tr>
+      <tr><td>T-009</td><td>Circuit</td><td>E = shield return, 50–60 K, about 20 K rise</td><td>KEEP</td></tr>
+      <tr><td>T-010</td><td>Colour</td><td>Temperature determines colour; 2, 4, 30, 50, 60, 77 K and separate 77–300 K scale</td><td>KEEP</td></tr>
+      <tr><td>T-011</td><td>Pressure</td><td>Low pressure = 27 mbar to 1.2 bar; high pressure = 1.2 bar to 15 bar</td><td>NEW</td></tr>
+      <tr><td>T-012</td><td>Heat flow</td><td>Nominal heat flow is high temperature to low temperature</td><td>KEEP</td></tr>
+    </tbody>
+  </table>
 | T-013 | Reverse flow | If 2K mass is warmer than 50K shield, inner parasitic path reverses | NEW |
 | T-014 | Load | 300→50 radiation | KEEP |
 | T-015 | Load | 300→50 conduction through supports/tyrods | KEEP |

--- a/docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.html
+++ b/docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.html
@@ -61,100 +61,120 @@
       <tr><td>T-010</td><td>Colour</td><td>Temperature determines colour; 2, 4, 30, 50, 60, 77 K and separate 77–300 K scale</td><td>KEEP</td></tr>
       <tr><td>T-011</td><td>Pressure</td><td>Low pressure = 27 mbar to 1.2 bar; high pressure = 1.2 bar to 15 bar</td><td>NEW</td></tr>
       <tr><td>T-012</td><td>Heat flow</td><td>Nominal heat flow is high temperature to low temperature</td><td>KEEP</td></tr>
+      <tr><td>T-013</td><td>Reverse flow</td><td>If 2K mass is warmer than 50K shield, inner parasitic path reverses</td><td>NEW</td></tr>
+      <tr><td>T-014</td><td>Load</td><td>300→50 radiation</td><td>KEEP</td></tr>
+      <tr><td>T-015</td><td>Load</td><td>300→50 conduction through supports/tyrods</td><td>KEEP</td></tr>
+      <tr><td>T-016</td><td>Load</td><td>50→2 radiation</td><td>KEEP</td></tr>
+      <tr><td>T-017</td><td>Load</td><td>50→2 conduction</td><td>KEEP</td></tr>
+      <tr><td>T-018</td><td>View</td><td>Temperature mode</td><td>KEEP</td></tr>
+      <tr><td>T-019</td><td>View</td><td>Pressure mode</td><td>REFINE</td></tr>
+      <tr><td>T-020</td><td>View</td><td>Nominal / all cold</td><td>PRIMARY</td></tr>
+      <tr><td>T-021</td><td>View</td><td>Warm / all at 300 K</td><td>NEW</td></tr>
+      <tr><td>T-022</td><td>View</td><td>Active cooldown</td><td>NEW</td></tr>
+      <tr><td>T-023</td><td>View</td><td>Passive warm-up / A-B off</td><td>NEW</td></tr>
+      <tr><td>T-024</td><td>Output</td><td>HTML-hosted interactive SVG</td><td>KEEP</td></tr>
+      <tr><td>T-025</td><td>Output</td><td>Rendered Markdown report</td><td>NEW</td></tr>
+      <tr><td>T-026</td><td>Output</td><td>GitHub Pages repo package</td><td>KEEP</td></tr>
+      <tr><td>T-027</td><td>Governance</td><td>Changelog + lineage per version</td><td>EXPAND</td></tr>
     </tbody>
   </table>
-| T-013 | Reverse flow | If 2K mass is warmer than 50K shield, inner parasitic path reverses | NEW |
-| T-014 | Load | 300→50 radiation | KEEP |
-| T-015 | Load | 300→50 conduction through supports/tyrods | KEEP |
-| T-016 | Load | 50→2 radiation | KEEP |
-| T-017 | Load | 50→2 conduction | KEEP |
-| T-018 | View | Temperature mode | KEEP |
-| T-019 | View | Pressure mode | REFINE |
-| T-020 | View | Nominal / all cold | PRIMARY |
-| T-021 | View | Warm / all at 300 K | NEW |
-| T-022 | View | Active cooldown | NEW |
-| T-023 | View | Passive warm-up / A-B off | NEW |
-| T-024 | Output | HTML-hosted interactive SVG | KEEP |
-| T-025 | Output | Rendered Markdown report | NEW |
-| T-026 | Output | GitHub Pages repo package | KEEP |
-| T-027 | Governance | Changelog + lineage per version | EXPAND |
 
-## Version lineage
+  <h2>Version lineage</h2>
 
-| Version | Useful content | Control decision |
-|---|---|---|
-| v0.1 | Temperature colour bar and interactive seed | Preserve |
-| v0.2 | YAML source, GitHub Pages scaffold, changelog | Preserve |
-| v0.3 | A/B/D/E, bidirectional boundary, parasitic placeholders | Preserve as best prior HTML |
-| v0.4.1 | Better narrative and protected-core concept | Preserve; stop PPT-first |
-| v0.5.0 | Storyboard seed | Preserve only as text/narrative |
-| v0.6.0 | Governance baseline | Current |
-| v0.7.0 | SVG grammar/style proof | Planned |
-| v0.8.0 | Nominal all-cold physics | Planned |
-| v0.9.0 | Modes, reversal logic, equations | Planned |
-| v1.0.0 | Hosted master release | Planned |
+  <table>
+    <thead>
+      <tr>
+        <th>Version</th>
+        <th>Useful content</th>
+        <th>Control decision</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>v0.1</td><td>Temperature colour bar and interactive seed</td><td>Preserve</td></tr>
+      <tr><td>v0.2</td><td>YAML source, GitHub Pages scaffold, changelog</td><td>Preserve</td></tr>
+      <tr><td>v0.3</td><td>A/B/D/E, bidirectional boundary, parasitic placeholders</td><td>Preserve as best prior HTML</td></tr>
+      <tr><td>v0.4.1</td><td>Better narrative and protected-core concept</td><td>Preserve; stop PPT-first</td></tr>
+      <tr><td>v0.5.0</td><td>Storyboard seed</td><td>Preserve only as text/narrative</td></tr>
+      <tr><td>v0.6.0</td><td>Governance baseline</td><td>Current</td></tr>
+      <tr><td>v0.7.0</td><td>SVG grammar/style proof</td><td>Planned</td></tr>
+      <tr><td>v0.8.0</td><td>Nominal all-cold physics</td><td>Planned</td></tr>
+      <tr><td>v0.9.0</td><td>Modes, reversal logic, equations</td><td>Planned</td></tr>
+      <tr><td>v1.0.0</td><td>Hosted master release</td><td>Planned</td></tr>
+    </tbody>
+  </table>
 
-## Phase plan
+  <h2>Phase plan</h2>
 
-### Phase 0 — Freeze and preserve
-Tasks: archive prior artefacts; define tuple set; mark PPT as reference-only; create changelog and lineage baseline.  
-Exit: v0.6.0 governance pack approved.
+  <h3>Phase 0 — Freeze and preserve</h3>
+  <p>Tasks: archive prior artefacts; define tuple set; mark PPT as reference-only; create changelog and lineage baseline.<br>
+  Exit: v0.6.0 governance pack approved.</p>
 
-### Phase 1 — SVG grammar and visual system
-Tasks: define temperature map, pressure map, arrow grammar, boundaries, warm/cold cards, and callout style.  
-Exit: static SVG style proof accepted.
+  <h3>Phase 1 — SVG grammar and visual system</h3>
+  <p>Tasks: define temperature map, pressure map, arrow grammar, boundaries, warm/cold cards, and callout style.<br>
+  Exit: static SVG style proof accepted.</p>
 
-### Phase 2 — Nominal case: everything already cold
-Tasks: draw 2K mass, vacuum, MLI, 50K shield, 300K boundary, A/B, D/E, and 300→50 / 50→2 heat leaks.  
-Exit: heat-flow directions, labels, colours, and boundaries accepted.
+  <h3>Phase 2 — Nominal case: everything already cold</h3>
+  <p>Tasks: draw 2K mass, vacuum, MLI, 50K shield, 300K boundary, A/B, D/E, and 300→50 / 50→2 heat leaks.<br>
+  Exit: heat-flow directions, labels, colours, and boundaries accepted.</p>
 
-### Phase 3 — Pressure and circuit views
-Tasks: add pressure toggle with low-pressure and high-pressure domains; preserve geometry.  
-Exit: pressure colours visibly distinct and line labels correct.
+  <h3>Phase 3 — Pressure and circuit views</h3>
+  <p>Tasks: add pressure toggle with low-pressure and high-pressure domains; preserve geometry.<br>
+  Exit: pressure colours visibly distinct and line labels correct.</p>
 
-### Phase 4 — Transient and reverse-flow logic
-Tasks: add state selector for nominal, warm start, active cooldown, passive warm-up; implement sign-change logic.  
-Exit: reversal arrows and state text are explicit.
+  <h3>Phase 4 — Transient and reverse-flow logic</h3>
+  <p>Tasks: add state selector for nominal, warm start, active cooldown, passive warm-up; implement sign-change logic.<br>
+  Exit: reversal arrows and state text are explicit.</p>
 
-### Phase 5 — MASTER integrated view
-Tasks: combine boundaries, masses, circuits, radiation, conduction, equations, legends, toggles, and YAML panel.  
-Exit: readable integrated SVG/HTML.
+  <h3>Phase 5 — MASTER integrated view</h3>
+  <p>Tasks: combine boundaries, masses, circuits, radiation, conduction, equations, legends, toggles, and YAML panel.<br>
+  Exit: readable integrated SVG/HTML.</p>
 
-### Phase 6 — GitHub Pages release
-Tasks: package repo, generator, changelog, review checklist, and GitHub Pages workflow.  
-Exit: `/docs/index.html` works locally and in GitHub Pages.
+  <h3>Phase 6 — GitHub Pages release</h3>
+  <p>Tasks: package repo, generator, changelog, review checklist, and GitHub Pages workflow.<br>
+  Exit: <code>/docs/index.html</code> works locally and in GitHub Pages.</p>
 
-## Recursive tuple update protocol
+  <h2>Recursive tuple update protocol</h2>
 
-```yaml
-tuple_update:
+  <pre><code>tuple_update:
   id: T-###
   action: add | modify | supersede | deprecate
   source: user | generated | derived
   affects: [ssot_yaml, svg, html, markdown, changelog]
-  validation: [visual_review, physics_consistency, idempotent_regeneration]
-```
+  validation: [visual_review, physics_consistency, idempotent_regeneration]</code></pre>
 
-## Progress tracker
+  <h2>Progress tracker</h2>
 
-| Phase | Status | Next action |
-|---|---:|---|
-| 0 Freeze and preserve | IN PROGRESS | Review v0.6.0 governance pack |
-| 1 SVG grammar | NOT STARTED | Build v0.7 style proof |
-| 2 Nominal case | NOT STARTED | Build nominal SVG |
-| 3 Pressure/circuit views | NOT STARTED | Refine pressure scale |
-| 4 Transient/reverse flow | NOT STARTED | Add state logic |
-| 5 MASTER view | NOT STARTED | Integrate layers |
-| 6 GitHub release | NOT STARTED | Package repo |
+  <table>
+    <thead>
+      <tr>
+        <th>Phase</th>
+        <th style="text-align: right;">Status</th>
+        <th>Next action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>0 Freeze and preserve</td><td style="text-align: right;">IN PROGRESS</td><td>Review v0.6.0 governance pack</td></tr>
+      <tr><td>1 SVG grammar</td><td style="text-align: right;">NOT STARTED</td><td>Build v0.7 style proof</td></tr>
+      <tr><td>2 Nominal case</td><td style="text-align: right;">NOT STARTED</td><td>Build nominal SVG</td></tr>
+      <tr><td>3 Pressure/circuit views</td><td style="text-align: right;">NOT STARTED</td><td>Refine pressure scale</td></tr>
+      <tr><td>4 Transient/reverse flow</td><td style="text-align: right;">NOT STARTED</td><td>Add state logic</td></tr>
+      <tr><td>5 MASTER view</td><td style="text-align: right;">NOT STARTED</td><td>Integrate layers</td></tr>
+      <tr><td>6 GitHub release</td><td style="text-align: right;">NOT STARTED</td><td>Package repo</td></tr>
+    </tbody>
+  </table>
 
-## Immediate action list
+  <h2>Immediate action list</h2>
 
-1. Accept v0.6.0 as rebuild baseline.
-2. Build v0.7.0 SVG style proof only.
-3. Review arrows, boundaries, colour scales, card layout.
-4. Build v0.8.0 nominal all-cold case.
-5. Add pressure mode after geometry is accepted.
-6. Add transient/reverse-flow logic after nominal is correct.
-7. Generate final HTML-hosted MASTER view.
-8. Export optional PPT only at the end.
-</pre></body></html>
+  <ol>
+    <li>Accept v0.6.0 as rebuild baseline.</li>
+    <li>Build v0.7.0 SVG style proof only.</li>
+    <li>Review arrows, boundaries, colour scales, card layout.</li>
+    <li>Build v0.8.0 nominal all-cold case.</li>
+    <li>Add pressure mode after geometry is accepted.</li>
+    <li>Add transient/reverse-flow logic after nominal is correct.</li>
+    <li>Generate final HTML-hosted MASTER view.</li>
+    <li>Export optional PPT only at the end.</li>
+  </ol>
+
+</body>
+</html>

--- a/docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.html
+++ b/docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.html
@@ -1,0 +1,134 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><title>QCELL SVG Rebuild Governance v0.6.0</title></head><body><pre># QCELL SVG Rebuild Governance Plan v0.6.0
+
+## Decision: stop PPT-first drift
+
+The PPT deck is now a **reference source**, not the production artefact. The rebuild starts from **versioned SVG/HTML + SSOT YAML + rendered Markdown**. Optional PPT/PDF exports come only after the SVG model is stable.
+
+## Source basis
+
+- Uploaded QCELL staged concept deck: nested 2K mass, 50K shield, MLI, vacuum, ambient boundary, radiation and conduction sources.
+- Raw conversation and tuple file: temperature colour rules, pressure mode, A/B and D/E circuits, parasitic-load semantics, GitHub-hosted HTML requirement.
+- Existing v0.3.0 HTML/SVG: keep interaction, YAML panel, pressure/temperature toggle, named lines, boundaries, and changelog structure.
+- Existing v0.4.1 artefact: preserve the improved narrative and SSOT idea.
+- v0.5.0 narrative: keep only as storyboard seed.
+
+## Rebuild principles
+
+1. Do not break existing versions.
+2. SVG is the drawing source; HTML is the hosted interactive wrapper.
+3. YAML is the SSOT for labels, values, colours, equations, views, and lineage.
+4. Re-running with the same YAML must produce the same SVG/HTML.
+5. Each revision updates tuple inventory, changelog, lineage, review checklist, SVG, HTML, and Markdown.
+6. User steering happens at phase gates on small SVG/HTML increments.
+
+## Master tuple set
+
+| Tuple | Domain | Meaning | Status |
+|---|---|---|---|
+| T-001 | Mass | 2K_mass is the protected liquid-helium core / JT black-box region | KEEP |
+| T-002 | Barrier | White annulus is vacuum barrier | KEEP |
+| T-003 | Shield | 50K thermal shield protects the 2K mass | KEEP |
+| T-004 | MLI | Blue/orange membrane indicates MLI + shield layer | KEEP |
+| T-005 | Ambient | Outer boundary is 293.15 K nominal / 300 K design | KEEP |
+| T-006 | Circuit | A = 2K supply, supercritical He, 4.5 K, 3 bar | KEEP |
+| T-007 | Circuit | B = 2K return, 2–4 K, 26–31 mbar | KEEP |
+| T-008 | Circuit | D = shield supply, 30–40 K, 12–13 bar | KEEP |
+| T-009 | Circuit | E = shield return, 50–60 K, about 20 K rise | KEEP |
+| T-010 | Colour | Temperature determines colour; 2, 4, 30, 50, 60, 77 K and separate 77–300 K scale | KEEP |
+| T-011 | Pressure | Low pressure = 27 mbar to 1.2 bar; high pressure = 1.2 bar to 15 bar | NEW |
+| T-012 | Heat flow | Nominal heat flow is high temperature to low temperature | KEEP |
+| T-013 | Reverse flow | If 2K mass is warmer than 50K shield, inner parasitic path reverses | NEW |
+| T-014 | Load | 300→50 radiation | KEEP |
+| T-015 | Load | 300→50 conduction through supports/tyrods | KEEP |
+| T-016 | Load | 50→2 radiation | KEEP |
+| T-017 | Load | 50→2 conduction | KEEP |
+| T-018 | View | Temperature mode | KEEP |
+| T-019 | View | Pressure mode | REFINE |
+| T-020 | View | Nominal / all cold | PRIMARY |
+| T-021 | View | Warm / all at 300 K | NEW |
+| T-022 | View | Active cooldown | NEW |
+| T-023 | View | Passive warm-up / A-B off | NEW |
+| T-024 | Output | HTML-hosted interactive SVG | KEEP |
+| T-025 | Output | Rendered Markdown report | NEW |
+| T-026 | Output | GitHub Pages repo package | KEEP |
+| T-027 | Governance | Changelog + lineage per version | EXPAND |
+
+## Version lineage
+
+| Version | Useful content | Control decision |
+|---|---|---|
+| v0.1 | Temperature colour bar and interactive seed | Preserve |
+| v0.2 | YAML source, GitHub Pages scaffold, changelog | Preserve |
+| v0.3 | A/B/D/E, bidirectional boundary, parasitic placeholders | Preserve as best prior HTML |
+| v0.4.1 | Better narrative and protected-core concept | Preserve; stop PPT-first |
+| v0.5.0 | Storyboard seed | Preserve only as text/narrative |
+| v0.6.0 | Governance baseline | Current |
+| v0.7.0 | SVG grammar/style proof | Planned |
+| v0.8.0 | Nominal all-cold physics | Planned |
+| v0.9.0 | Modes, reversal logic, equations | Planned |
+| v1.0.0 | Hosted master release | Planned |
+
+## Phase plan
+
+### Phase 0 — Freeze and preserve
+Tasks: archive prior artefacts; define tuple set; mark PPT as reference-only; create changelog and lineage baseline.  
+Exit: v0.6.0 governance pack approved.
+
+### Phase 1 — SVG grammar and visual system
+Tasks: define temperature map, pressure map, arrow grammar, boundaries, warm/cold cards, and callout style.  
+Exit: static SVG style proof accepted.
+
+### Phase 2 — Nominal case: everything already cold
+Tasks: draw 2K mass, vacuum, MLI, 50K shield, 300K boundary, A/B, D/E, and 300→50 / 50→2 heat leaks.  
+Exit: heat-flow directions, labels, colours, and boundaries accepted.
+
+### Phase 3 — Pressure and circuit views
+Tasks: add pressure toggle with low-pressure and high-pressure domains; preserve geometry.  
+Exit: pressure colours visibly distinct and line labels correct.
+
+### Phase 4 — Transient and reverse-flow logic
+Tasks: add state selector for nominal, warm start, active cooldown, passive warm-up; implement sign-change logic.  
+Exit: reversal arrows and state text are explicit.
+
+### Phase 5 — MASTER integrated view
+Tasks: combine boundaries, masses, circuits, radiation, conduction, equations, legends, toggles, and YAML panel.  
+Exit: readable integrated SVG/HTML.
+
+### Phase 6 — GitHub Pages release
+Tasks: package repo, generator, changelog, review checklist, and GitHub Pages workflow.  
+Exit: `/docs/index.html` works locally and in GitHub Pages.
+
+## Recursive tuple update protocol
+
+```yaml
+tuple_update:
+  id: T-###
+  action: add | modify | supersede | deprecate
+  source: user | generated | derived
+  affects: [ssot_yaml, svg, html, markdown, changelog]
+  validation: [visual_review, physics_consistency, idempotent_regeneration]
+```
+
+## Progress tracker
+
+| Phase | Status | Next action |
+|---|---:|---|
+| 0 Freeze and preserve | IN PROGRESS | Review v0.6.0 governance pack |
+| 1 SVG grammar | NOT STARTED | Build v0.7 style proof |
+| 2 Nominal case | NOT STARTED | Build nominal SVG |
+| 3 Pressure/circuit views | NOT STARTED | Refine pressure scale |
+| 4 Transient/reverse flow | NOT STARTED | Add state logic |
+| 5 MASTER view | NOT STARTED | Integrate layers |
+| 6 GitHub release | NOT STARTED | Package repo |
+
+## Immediate action list
+
+1. Accept v0.6.0 as rebuild baseline.
+2. Build v0.7.0 SVG style proof only.
+3. Review arrows, boundaries, colour scales, card layout.
+4. Build v0.8.0 nominal all-cold case.
+5. Add pressure mode after geometry is accepted.
+6. Add transient/reverse-flow logic after nominal is correct.
+7. Generate final HTML-hosted MASTER view.
+8. Export optional PPT only at the end.
+</pre></body></html>

--- a/docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.md
+++ b/docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.md
@@ -39,7 +39,7 @@ The PPT deck is now a **reference source**, not the production artefact. The reb
 | T-012 | Heat flow | Nominal heat flow is high temperature to low temperature | KEEP |
 | T-013 | Reverse flow | If 2K mass is warmer than 50K shield, inner parasitic path reverses | NEW |
 | T-014 | Load | 300→50 radiation | KEEP |
-| T-015 | Load | 300→50 conduction through supports/tyrods | KEEP |
+| T-015 | Load | 300→50 conduction through supports/tie rods | KEEP |
 | T-016 | Load | 50→2 radiation | KEEP |
 | T-017 | Load | 50→2 conduction | KEEP |
 | T-018 | View | Temperature mode | KEEP |

--- a/docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.md
+++ b/docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.md
@@ -1,0 +1,133 @@
+# QCELL SVG Rebuild Governance Plan v0.6.0
+
+## Decision: stop PPT-first drift
+
+The PPT deck is now a **reference source**, not the production artefact. The rebuild starts from **versioned SVG/HTML + SSOT YAML + rendered Markdown**. Optional PPT/PDF exports come only after the SVG model is stable.
+
+## Source basis
+
+- Uploaded QCELL staged concept deck: nested 2K mass, 50K shield, MLI, vacuum, ambient boundary, radiation and conduction sources.
+- Raw conversation and tuple file: temperature colour rules, pressure mode, A/B and D/E circuits, parasitic-load semantics, GitHub-hosted HTML requirement.
+- Existing v0.3.0 HTML/SVG: keep interaction, YAML panel, pressure/temperature toggle, named lines, boundaries, and changelog structure.
+- Existing v0.4.1 artefact: preserve the improved narrative and SSOT idea.
+- v0.5.0 narrative: keep only as storyboard seed.
+
+## Rebuild principles
+
+1. Do not break existing versions.
+2. SVG is the drawing source; HTML is the hosted interactive wrapper.
+3. YAML is the SSOT for labels, values, colours, equations, views, and lineage.
+4. Re-running with the same YAML must produce the same SVG/HTML.
+5. Each revision updates tuple inventory, changelog, lineage, review checklist, SVG, HTML, and Markdown.
+6. User steering happens at phase gates on small SVG/HTML increments.
+
+## Master tuple set
+
+| Tuple | Domain | Meaning | Status |
+|---|---|---|---|
+| T-001 | Mass | 2K_mass is the protected liquid-helium core / JT black-box region | KEEP |
+| T-002 | Barrier | White annulus is vacuum barrier | KEEP |
+| T-003 | Shield | 50K thermal shield protects the 2K mass | KEEP |
+| T-004 | MLI | Blue/orange membrane indicates MLI + shield layer | KEEP |
+| T-005 | Ambient | Outer boundary is 293.15 K nominal / 300 K design | KEEP |
+| T-006 | Circuit | A = 2K supply, supercritical He, 4.5 K, 3 bar | KEEP |
+| T-007 | Circuit | B = 2K return, 2–4 K, 26–31 mbar | KEEP |
+| T-008 | Circuit | D = shield supply, 30–40 K, 12–13 bar | KEEP |
+| T-009 | Circuit | E = shield return, 50–60 K, about 20 K rise | KEEP |
+| T-010 | Colour | Temperature determines colour; 2, 4, 30, 50, 60, 77 K and separate 77–300 K scale | KEEP |
+| T-011 | Pressure | Low pressure = 27 mbar to 1.2 bar; high pressure = 1.2 bar to 15 bar | NEW |
+| T-012 | Heat flow | Nominal heat flow is high temperature to low temperature | KEEP |
+| T-013 | Reverse flow | If 2K mass is warmer than 50K shield, inner parasitic path reverses | NEW |
+| T-014 | Load | 300→50 radiation | KEEP |
+| T-015 | Load | 300→50 conduction through supports/tyrods | KEEP |
+| T-016 | Load | 50→2 radiation | KEEP |
+| T-017 | Load | 50→2 conduction | KEEP |
+| T-018 | View | Temperature mode | KEEP |
+| T-019 | View | Pressure mode | REFINE |
+| T-020 | View | Nominal / all cold | PRIMARY |
+| T-021 | View | Warm / all at 300 K | NEW |
+| T-022 | View | Active cooldown | NEW |
+| T-023 | View | Passive warm-up / A-B off | NEW |
+| T-024 | Output | HTML-hosted interactive SVG | KEEP |
+| T-025 | Output | Rendered Markdown report | NEW |
+| T-026 | Output | GitHub Pages repo package | KEEP |
+| T-027 | Governance | Changelog + lineage per version | EXPAND |
+
+## Version lineage
+
+| Version | Useful content | Control decision |
+|---|---|---|
+| v0.1 | Temperature colour bar and interactive seed | Preserve |
+| v0.2 | YAML source, GitHub Pages scaffold, changelog | Preserve |
+| v0.3 | A/B/D/E, bidirectional boundary, parasitic placeholders | Preserve as best prior HTML |
+| v0.4.1 | Better narrative and protected-core concept | Preserve; stop PPT-first |
+| v0.5.0 | Storyboard seed | Preserve only as text/narrative |
+| v0.6.0 | Governance baseline | Current |
+| v0.7.0 | SVG grammar/style proof | Planned |
+| v0.8.0 | Nominal all-cold physics | Planned |
+| v0.9.0 | Modes, reversal logic, equations | Planned |
+| v1.0.0 | Hosted master release | Planned |
+
+## Phase plan
+
+### Phase 0 — Freeze and preserve
+Tasks: archive prior artefacts; define tuple set; mark PPT as reference-only; create changelog and lineage baseline.  
+Exit: v0.6.0 governance pack approved.
+
+### Phase 1 — SVG grammar and visual system
+Tasks: define temperature map, pressure map, arrow grammar, boundaries, warm/cold cards, and callout style.  
+Exit: static SVG style proof accepted.
+
+### Phase 2 — Nominal case: everything already cold
+Tasks: draw 2K mass, vacuum, MLI, 50K shield, 300K boundary, A/B, D/E, and 300→50 / 50→2 heat leaks.  
+Exit: heat-flow directions, labels, colours, and boundaries accepted.
+
+### Phase 3 — Pressure and circuit views
+Tasks: add pressure toggle with low-pressure and high-pressure domains; preserve geometry.  
+Exit: pressure colours visibly distinct and line labels correct.
+
+### Phase 4 — Transient and reverse-flow logic
+Tasks: add state selector for nominal, warm start, active cooldown, passive warm-up; implement sign-change logic.  
+Exit: reversal arrows and state text are explicit.
+
+### Phase 5 — MASTER integrated view
+Tasks: combine boundaries, masses, circuits, radiation, conduction, equations, legends, toggles, and YAML panel.  
+Exit: readable integrated SVG/HTML.
+
+### Phase 6 — GitHub Pages release
+Tasks: package repo, generator, changelog, review checklist, and GitHub Pages workflow.  
+Exit: `/docs/index.html` works locally and in GitHub Pages.
+
+## Recursive tuple update protocol
+
+```yaml
+tuple_update:
+  id: T-###
+  action: add | modify | supersede | deprecate
+  source: user | generated | derived
+  affects: [ssot_yaml, svg, html, markdown, changelog]
+  validation: [visual_review, physics_consistency, idempotent_regeneration]
+```
+
+## Progress tracker
+
+| Phase | Status | Next action |
+|---|---:|---|
+| 0 Freeze and preserve | IN PROGRESS | Review v0.6.0 governance pack |
+| 1 SVG grammar | NOT STARTED | Build v0.7 style proof |
+| 2 Nominal case | NOT STARTED | Build nominal SVG |
+| 3 Pressure/circuit views | NOT STARTED | Refine pressure scale |
+| 4 Transient/reverse flow | NOT STARTED | Add state logic |
+| 5 MASTER view | NOT STARTED | Integrate layers |
+| 6 GitHub release | NOT STARTED | Package repo |
+
+## Immediate action list
+
+1. Accept v0.6.0 as rebuild baseline.
+2. Build v0.7.0 SVG style proof only.
+3. Review arrows, boundaries, colour scales, card layout.
+4. Build v0.8.0 nominal all-cold case.
+5. Add pressure mode after geometry is accepted.
+6. Add transient/reverse-flow logic after nominal is correct.
+7. Generate final HTML-hosted MASTER view.
+8. Export optional PPT only at the end.

--- a/docs/qcell_svg_rebuild_v0_6_0/lineage/source_lineage_v0_6_0.json
+++ b/docs/qcell_svg_rebuild_v0_6_0/lineage/source_lineage_v0_6_0.json
@@ -5,7 +5,7 @@
     "QCELL cool down model and masses.pptx",
     "Raw conversation and tuple.txt",
     "helium_thermal_pressure_v0_3_0.html",
-    "preview_output_genererate.html",
+    "preview_output_generate.html",
     "QCELL_cool_down_model_and_masses_v0_4_1.pptx",
     "QCELL_thermal_SSOT_v0_5_0.yaml",
     "QCELL_thermal_narrative_v0_5_0.pptx",

--- a/docs/qcell_svg_rebuild_v0_6_0/lineage/source_lineage_v0_6_0.json
+++ b/docs/qcell_svg_rebuild_v0_6_0/lineage/source_lineage_v0_6_0.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.6.0",
+  "preserve_do_not_overwrite": true,
+  "sources": [
+    "QCELL cool down model and masses.pptx",
+    "Raw conversation and tuple.txt",
+    "helium_thermal_pressure_v0_3_0.html",
+    "preview_output_genererate.html",
+    "QCELL_cool_down_model_and_masses_v0_4_1.pptx",
+    "QCELL_thermal_SSOT_v0_5_0.yaml",
+    "QCELL_thermal_narrative_v0_5_0.pptx",
+    "QCELL_thermal_narrative_v0_5_0.docx",
+    "preview.html"
+  ],
+  "primary_artifact_chain": ["YAML", "SVG", "HTML", "Markdown"],
+  "deprecated_primary_chain": ["PPT-first"]
+}

--- a/docs/qcell_svg_rebuild_v0_6_0/reviews/review_gate_v0_6_0.md
+++ b/docs/qcell_svg_rebuild_v0_6_0/reviews/review_gate_v0_6_0.md
@@ -1,0 +1,10 @@
+# Review Gate v0.6.0
+
+- [x] PPT-first workflow stopped.
+- [x] Existing artefacts preserved.
+- [x] SVG/HTML/YAML/Markdown accepted as primary chain.
+- [x] Tuple set captures current requirements.
+- [x] Phase plan acceptable.
+- [x] Pressure domains accepted.
+- [x] Temperature domains accepted.
+- [x] Nominal first, transient later accepted.

--- a/docs/qcell_svg_rebuild_v0_6_0/src/rebuild_governance.yaml
+++ b/docs/qcell_svg_rebuild_v0_6_0/src/rebuild_governance.yaml
@@ -1,0 +1,11 @@
+schema_version: 0.6.0
+package_type: qcell_svg_rebuild_governance
+decision: stop_ppt_first_drift
+primary_artifact_chain: [ssot_yaml, versioned_svg, hosted_html, rendered_markdown]
+ppt_policy: reference_source_and_export_only
+idempotency:
+  same_yaml_same_svg: true
+  same_yaml_same_html: true
+  versioned_outputs_only: true
+  phase_gate_review: true
+next_version: v0.7.0_style_proof


### PR DESCRIPTION
### Motivation
- Establish v0.6.0 as a governance/reset baseline to stop the PPT-first workflow drift and treat PPT as a reference export only.
- Freeze and preserve prior artefacts and capture a single-source-of-truth (SSOT) workflow where YAML/SVG/HTML/Markdown are primary artefacts.
- Define the immediate roadmap and scope for the next build (`v0.7.0` as an SVG grammar/style proof only).

### Description
- Add a governance package under `docs/qcell_svg_rebuild_v0_6_0/` containing the rebuild plan, changelog, review gate, lineage, and SSOT YAML.
- Files added: `docs_rebuild_plan.md`, `docs_rebuild_plan.html`, `src/rebuild_governance.yaml`, `CHANGELOG.md`, `reviews/review_gate_v0_6_0.md`, and `lineage/source_lineage_v0_6_0.json`.
- The `rebuild_governance.yaml` declares `primary_artifact_chain`, idempotency expectations, and `next_version: v0.7.0_style_proof`.
- The Markdown plan contains the tuple inventory, phased roadmap, recursive tuple update protocol, progress tracker, and immediate action list.

### Testing
- Ran the markdown-to-HTML conversion via the inline Python invocation (`python - <<'PY' ... PY`) which successfully produced `docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.html`.
- Verified that all new files were created and written to disk under `docs/qcell_svg_rebuild_v0_6_0/` as listed above.
- No code or runtime paths were modified, so no unit or integration tests were required or run for code changes; documentation-only changes validated as present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0622408a74832e8ef1dd4e1c8cc39c)