### PR TITLE
QPS Slide System v0.4 — HTML-first dense engineering master-slide architecture

### DIFF
--- a/docs/qps-slide-system/CHANGELOG.md
+++ b/docs/qps-slide-system/CHANGELOG.md
@@ -1,0 +1,31 @@
+# CHANGELOG — QPS Master Slide System
+
+## v0.4.0
+
+### Added
+
+- HTML-first navigation/index architecture.
+- Initial deck split:
+  - STYLE_SYSTEM
+  - SBS_NAMING
+  - CONTROL_SYSTEM
+  - UTILITIES_SYSTEM
+- First-pass master-slide candidates.
+- Recursive/idempotent/evolutionary DMAIC model.
+- KPI tracking and phase maturity metrics.
+- YAML source model draft.
+
+### Key Findings
+
+- Dense engineering master slides should remain high-density.
+- Duplicates should become references/interludes rather than repeated slides.
+- Tree vs Links is a core architectural concept for QPS.
+- Styles are semantic visual dialects, not isolated themes.
+
+### Next Actions
+
+- Add canonical slide inventory.
+- Add schema.slide.yaml.
+- Add index.yaml.
+- Add rendered HTML master-slide examples.
+- Add reference/interlude linking system.

--- a/docs/qps-slide-system/CHANGELOG.md
+++ b/docs/qps-slide-system/CHANGELOG.md
@@ -4,16 +4,16 @@
 
 ### Added
 
-- HTML-first navigation/index architecture.
-- Initial deck split:
+- Initial documentation for the QPS master-slide system structure and direction.
+- Proposed HTML-first navigation/index architecture.
+- Proposed initial deck split:
   - STYLE_SYSTEM
   - SBS_NAMING
   - CONTROL_SYSTEM
   - UTILITIES_SYSTEM
-- First-pass master-slide candidates.
-- Recursive/idempotent/evolutionary DMAIC model.
-- KPI tracking and phase maturity metrics.
-- YAML source model draft.
+- First-pass documentation of master-slide candidates.
+- Draft definition of the recursive/idempotent/evolutionary DMAIC model.
+- Draft notes for KPI tracking, phase maturity metrics, and a YAML source model.
 
 ### Key Findings
 

--- a/docs/qps-slide-system/README.md
+++ b/docs/qps-slide-system/README.md
@@ -23,12 +23,16 @@ The goal is not low-density presentation design. The goal is dense, coherent, to
 YAML source -> HTML render -> PDF/PPTX review artefacts
 ```
 
-## Current artefacts
+## Current repository files
 
-- `index.html` — first HTML preview and navigation entry.
-- `index.yaml` — system/deck index draft.
-- `schema.slide.yaml` — draft slide source schema.
+- `README.md` — package overview, scope, and implementation direction.
 - `CHANGELOG.md` — versioned progress log.
+
+## Planned/generated artefacts
+
+- `index.html` — planned HTML preview and navigation entry.
+- `index.yaml` — planned system/deck index draft.
+- `schema.slide.yaml` — planned slide source schema draft.
 
 ## Review status
 

--- a/docs/qps-slide-system/README.md
+++ b/docs/qps-slide-system/README.md
@@ -1,0 +1,35 @@
+# QPS Master Slide System
+
+HTML-first dense engineering knowledge-transfer system for QPS slide decks.
+
+## Version
+
+`v0.4.0` — indexed master-output pass.
+
+## Purpose
+
+This package captures the current QPS slide-system direction developed from the uploaded candidate decks:
+
+- `STYLE_SYSTEM` — visual grammar, palette, overlays, navigation, review blocks.
+- `SBS_NAMING` — QSYS/QPS hierarchy, SBS, terminal points, tag grammar, Ultimo-style ontology mapping.
+- `CONTROL_SYSTEM` — QPS:CIS hierarchy, MIT/MIS/MCS signal philosophy, WCS.HCC inheritance, inhibition logic.
+- `UTILITIES_SYSTEM` — HVAC, PCW, RCW, ES02, LOOP, HCC heat-flow and operational assumptions.
+
+## Design Principle
+
+The goal is not low-density presentation design. The goal is dense, coherent, topic-specific master slides with controlled semantic navigation.
+
+```text
+YAML source -> HTML render -> PDF/PPTX review artefacts
+```
+
+## Current artefacts
+
+- `index.html` — first HTML preview and navigation entry.
+- `index.yaml` — system/deck index draft.
+- `schema.slide.yaml` — draft slide source schema.
+- `CHANGELOG.md` — versioned progress log.
+
+## Review status
+
+This is a first GitHub/Codex-ready scaffold. It intentionally keeps the render lightweight while preserving the architecture, terminology, and deck split for the next implementation pass.


### PR DESCRIPTION
## Summary

Introduces the first GitHub/Codex-ready scaffold for the QPS Master Slide System.

This PR establishes:

- HTML-first dense engineering slide architecture
- split deck philosophy
- recursive/idempotent/evolutionary DMAIC lifecycle
- KPI and maturity tracking
- YAML-first semantic source direction
- initial navigation/index concept

## Initial deck split

- STYLE_SYSTEM
- SBS_NAMING
- CONTROL_SYSTEM
- UTILITIES_SYSTEM

## Key architectural findings

- Dense master slides should remain high-density.
- Duplicates become references/interludes instead of repeated slides.
- Tree vs Links is a central ontology concept.
- Styles are semantic visual dialects.

## Current state

This is intentionally a lightweight scaffold and architecture PR.
The next pass will add:

- rendered HTML examples
- schema.slide.yaml
- index.yaml
- canonical slide inventory
- interlude/reference navigation
- YAML-driven rendering

## Version

`v0.4.0`
