### PR TITLE
qps-slide-system: add v0.5.0 HTML render, YAML decks, style tokens, and duplicate/reference map

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -33,7 +33,8 @@
     "docs/plots/*.html",
     "docs/leak_baseline/index.html",
     "docs/HUMAN.*.html",
-    "docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.html"
+    "docs/qcell_svg_rebuild_v0_6_0/docs_rebuild_plan.html",
+    "docs/qps-slide-system/index.html"
   ],
   "controls": {
     "link_check_required": true,

--- a/docs/qps-slide-system/CHANGELOG.md
+++ b/docs/qps-slide-system/CHANGELOG.md
@@ -29,3 +29,14 @@
 - Add index.yaml.
 - Add rendered HTML master-slide examples.
 - Add reference/interlude linking system.
+
+## v0.5.0
+
+### Added
+
+- Rendered `index.html` with HTML-native section anchors and navigation links.
+- Initial YAML index and deck files for STYLE_SYSTEM and CONTROL_SYSTEM.
+- Second master slide per deck to validate slide sequence behavior.
+- Reference/interlude linking between decks.
+- Duplicate/reference canonical map file.
+- Style token source file for color/spacing/typography/emphasis.

--- a/docs/qps-slide-system/README.md
+++ b/docs/qps-slide-system/README.md
@@ -4,7 +4,7 @@ HTML-first dense engineering knowledge-transfer system for QPS slide decks.
 
 ## Version
 
-`v0.4.0` — indexed master-output pass.
+`v0.5.0` — HTML render + YAML seed pass.
 
 ## Purpose
 
@@ -37,3 +37,11 @@ YAML source -> HTML render -> PDF/PPTX review artefacts
 ## Review status
 
 This is a first GitHub/Codex-ready scaffold. It intentionally keeps the render lightweight while preserving the architecture, terminology, and deck split for the next implementation pass.
+
+
+## v0.5 Delivery
+
+- Added runnable `index.html` with HTML-native navigation.
+- Added `index.yaml` system index.
+- Added first deck YAML files with two master slides each.
+- Added style token file and duplicate/reference map.

--- a/docs/qps-slide-system/decks/control_system.yaml
+++ b/docs/qps-slide-system/decks/control_system.yaml
@@ -1,0 +1,21 @@
+deck_id: CONTROL_SYSTEM
+title: Control System
+slides:
+  - id: CONTROL_SYSTEM_001
+    title: QPS:CIS Hierarchy
+    kind: master
+    body:
+      - QPS:CIS hierarchy defines signals, ownership, and control boundaries.
+      - MIT/MIS/MCS semantics are inherited through WCS.HCC layers.
+    links:
+      next: CONTROL_SYSTEM_002
+      reference: STYLE_SYSTEM_001
+  - id: CONTROL_SYSTEM_002
+    title: Inhibition and Interlock Logic
+    kind: master
+    body:
+      - Inhibition rules must be explicit, traceable, and test-linked.
+      - Interlocks should show trigger, effect, and reset semantics.
+    links:
+      prev: CONTROL_SYSTEM_001
+      interlude: STYLE_SYSTEM_002

--- a/docs/qps-slide-system/decks/style_system.yaml
+++ b/docs/qps-slide-system/decks/style_system.yaml
@@ -18,4 +18,4 @@ slides:
       - Use tokenized spacing and emphasis for consistent readability.
     links:
       prev: STYLE_SYSTEM_001
-      home: STYLE_SYSTEM_001
+      home: home

--- a/docs/qps-slide-system/decks/style_system.yaml
+++ b/docs/qps-slide-system/decks/style_system.yaml
@@ -1,0 +1,21 @@
+deck_id: STYLE_SYSTEM
+title: Style System
+slides:
+  - id: STYLE_SYSTEM_001
+    title: Semantic Visual Dialects
+    kind: master
+    body:
+      - Styles are semantic visual dialects, not isolated themes.
+      - Overlay grammar should communicate hierarchy and review status.
+    links:
+      next: STYLE_SYSTEM_002
+      reference: CONTROL_SYSTEM_001
+  - id: STYLE_SYSTEM_002
+    title: Dense Slide Composition Rules
+    kind: master
+    body:
+      - Preserve high-density engineering detail with strict sectioning.
+      - Use tokenized spacing and emphasis for consistent readability.
+    links:
+      prev: STYLE_SYSTEM_001
+      home: STYLE_SYSTEM_001

--- a/docs/qps-slide-system/index.html
+++ b/docs/qps-slide-system/index.html
@@ -102,10 +102,11 @@
     </div>
   </div>
   <script>
+    var MONO = 'Consolas, "Courier New", monospace';
     var FONTS = {
-      aptos:   { body: 'Aptos, Calibri, "Segoe UI", Arial, sans-serif',   mono: 'Consolas, "Courier New", monospace' },
-      inter:   { body: 'Inter, "Segoe UI", Arial, sans-serif',             mono: 'Consolas, "Courier New", monospace' },
-      georgia: { body: 'Georgia, "Times New Roman", serif',                mono: '"Courier New", monospace' }
+      aptos:   { body: 'Aptos, Calibri, "Segoe UI", Arial, sans-serif', mono: MONO },
+      inter:   { body: 'Inter, "Segoe UI", Arial, sans-serif',           mono: MONO },
+      georgia: { body: 'Georgia, "Times New Roman", serif',              mono: '"Courier New", monospace' }
     };
     function applyFont(key) {
       var f = FONTS[key] || FONTS.aptos;
@@ -114,8 +115,8 @@
       try { localStorage.setItem('qps-font', key); } catch(e) {}
     }
     (function init() {
-      var saved = '';
-      try { saved = localStorage.getItem('qps-font') || ''; } catch(e) {}
+      var saved;
+      try { saved = localStorage.getItem('qps-font') || 'aptos'; } catch(e) { saved = 'aptos'; }
       var key = FONTS[saved] ? saved : 'aptos';
       document.getElementById('font-select').value = key;
       applyFont(key);

--- a/docs/qps-slide-system/index.html
+++ b/docs/qps-slide-system/index.html
@@ -17,7 +17,7 @@
       --h1: 30px;
       --h2: 22px;
       --body: 15px;
-      --font: Inter, Segoe UI, Arial, sans-serif;
+      --font: Inter, "Segoe UI", Arial, sans-serif;
     }
     body { margin: 0; background: var(--bg); color: var(--text); font-family: var(--font); }
     .wrap { max-width: 980px; margin: 0 auto; padding: var(--space-lg); }
@@ -32,7 +32,7 @@
 </head>
 <body>
   <div class="wrap">
-    <h1>QPS Master Slide System <span class="meta">v0.5.0</span></h1>
+    <h1 id="home">QPS Master Slide System <span class="meta">v0.5.0</span></h1>
     <div class="slide" id="STYLE_SYSTEM_001">
       <h2>STYLE_SYSTEM_001 — Semantic Visual Dialects</h2>
       <ul>
@@ -53,7 +53,7 @@
       </ul>
       <nav>
         <a href="#STYLE_SYSTEM_001">Prev</a>
-        <a href="#STYLE_SYSTEM_001">Home</a>
+        <a href="#home">Home</a>
       </nav>
     </div>
 

--- a/docs/qps-slide-system/index.html
+++ b/docs/qps-slide-system/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>QPS Master Slide System v0.5</title>
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: #111827;
+      --text: #e5e7eb;
+      --accent: #22d3ee;
+      --warning: #f59e0b;
+      --space-sm: 8px;
+      --space-md: 12px;
+      --space-lg: 20px;
+      --h1: 30px;
+      --h2: 22px;
+      --body: 15px;
+      --font: Inter, Segoe UI, Arial, sans-serif;
+    }
+    body { margin: 0; background: var(--bg); color: var(--text); font-family: var(--font); }
+    .wrap { max-width: 980px; margin: 0 auto; padding: var(--space-lg); }
+    .slide { background: var(--panel); border-left: 4px solid var(--accent); padding: var(--space-lg); margin-bottom: var(--space-lg); }
+    h1 { margin-top: 0; font-size: var(--h1); }
+    h2 { font-size: var(--h2); margin-bottom: var(--space-md); }
+    p, li { font-size: var(--body); line-height: 1.4; }
+    nav a { color: var(--accent); margin-right: var(--space-md); text-decoration: none; }
+    .reference { color: var(--warning); }
+    .meta { opacity: 0.85; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>QPS Master Slide System <span class="meta">v0.5.0</span></h1>
+    <div class="slide" id="STYLE_SYSTEM_001">
+      <h2>STYLE_SYSTEM_001 — Semantic Visual Dialects</h2>
+      <ul>
+        <li>Styles are semantic visual dialects, not isolated themes.</li>
+        <li>Overlay grammar should communicate hierarchy and review status.</li>
+      </ul>
+      <nav>
+        <a href="#STYLE_SYSTEM_002">Next</a>
+        <a class="reference" href="#CONTROL_SYSTEM_001">Reference</a>
+      </nav>
+    </div>
+
+    <div class="slide" id="STYLE_SYSTEM_002">
+      <h2>STYLE_SYSTEM_002 — Dense Slide Composition Rules</h2>
+      <ul>
+        <li>Preserve high-density engineering detail with strict sectioning.</li>
+        <li>Use tokenized spacing and emphasis for consistent readability.</li>
+      </ul>
+      <nav>
+        <a href="#STYLE_SYSTEM_001">Prev</a>
+        <a href="#STYLE_SYSTEM_001">Home</a>
+      </nav>
+    </div>
+
+    <div class="slide" id="CONTROL_SYSTEM_001">
+      <h2>CONTROL_SYSTEM_001 — QPS:CIS Hierarchy</h2>
+      <ul>
+        <li>QPS:CIS hierarchy defines signals, ownership, and control boundaries.</li>
+        <li>MIT/MIS/MCS semantics are inherited through WCS.HCC layers.</li>
+      </ul>
+      <nav>
+        <a href="#CONTROL_SYSTEM_002">Next</a>
+        <a class="reference" href="#STYLE_SYSTEM_001">Reference</a>
+      </nav>
+    </div>
+
+    <div class="slide" id="CONTROL_SYSTEM_002">
+      <h2>CONTROL_SYSTEM_002 — Inhibition and Interlock Logic</h2>
+      <ul>
+        <li>Inhibition rules must be explicit, traceable, and test-linked.</li>
+        <li>Interlocks should show trigger, effect, and reset semantics.</li>
+      </ul>
+      <nav>
+        <a href="#CONTROL_SYSTEM_001">Prev</a>
+        <a class="reference" href="#STYLE_SYSTEM_002">Interlude</a>
+      </nav>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/qps-slide-system/index.html
+++ b/docs/qps-slide-system/index.html
@@ -17,7 +17,8 @@
       --h1: 30px;
       --h2: 22px;
       --body: 15px;
-      --font: Inter, "Segoe UI", Arial, sans-serif;
+      --font: Aptos, Calibri, "Segoe UI", Arial, sans-serif;
+      --font-mono: Consolas, "Courier New", monospace;
     }
     body { margin: 0; background: var(--bg); color: var(--text); font-family: var(--font); }
     .wrap { max-width: 980px; margin: 0 auto; padding: var(--space-lg); }
@@ -25,14 +26,33 @@
     h1 { margin-top: 0; font-size: var(--h1); }
     h2 { font-size: var(--h2); margin-bottom: var(--space-md); }
     p, li { font-size: var(--body); line-height: 1.4; }
+    code, pre { font-family: var(--font-mono); }
     nav a { color: var(--accent); margin-right: var(--space-md); text-decoration: none; }
     .reference { color: var(--warning); }
     .meta { opacity: 0.85; }
+    .toolbar {
+      display: flex; align-items: center; gap: var(--space-md);
+      margin-bottom: var(--space-lg); font-size: 13px;
+    }
+    .toolbar label { opacity: 0.75; }
+    .toolbar select {
+      background: var(--panel); color: var(--text);
+      border: 1px solid #334155; border-radius: 4px;
+      padding: 3px 8px; font-size: 13px; cursor: pointer;
+    }
   </style>
 </head>
 <body>
   <div class="wrap">
     <h1 id="home">QPS Master Slide System <span class="meta">v0.5.0</span></h1>
+    <div class="toolbar">
+      <label for="font-select">Font:</label>
+      <select id="font-select" onchange="applyFont(this.value)">
+        <option value="aptos">Aptos / Consolas</option>
+        <option value="inter">Inter / "Segoe UI"</option>
+        <option value="georgia">Georgia / Courier New</option>
+      </select>
+    </div>
     <div class="slide" id="STYLE_SYSTEM_001">
       <h2>STYLE_SYSTEM_001 — Semantic Visual Dialects</h2>
       <ul>
@@ -81,5 +101,25 @@
       </nav>
     </div>
   </div>
+  <script>
+    var FONTS = {
+      aptos:   { body: 'Aptos, Calibri, "Segoe UI", Arial, sans-serif',   mono: 'Consolas, "Courier New", monospace' },
+      inter:   { body: 'Inter, "Segoe UI", Arial, sans-serif',             mono: 'Consolas, "Courier New", monospace' },
+      georgia: { body: 'Georgia, "Times New Roman", serif',                mono: '"Courier New", monospace' }
+    };
+    function applyFont(key) {
+      var f = FONTS[key] || FONTS.aptos;
+      document.documentElement.style.setProperty('--font', f.body);
+      document.documentElement.style.setProperty('--font-mono', f.mono);
+      try { localStorage.setItem('qps-font', key); } catch(e) {}
+    }
+    (function init() {
+      var saved = '';
+      try { saved = localStorage.getItem('qps-font') || ''; } catch(e) {}
+      var key = FONTS[saved] ? saved : 'aptos';
+      document.getElementById('font-select').value = key;
+      applyFont(key);
+    })();
+  </script>
 </body>
 </html>

--- a/docs/qps-slide-system/index.yaml
+++ b/docs/qps-slide-system/index.yaml
@@ -1,0 +1,25 @@
+version: 0.5.0
+system: QPS_MASTER_SLIDES_SYSTEM
+entrypoint: index.html
+decks:
+  - id: STYLE_SYSTEM
+    title: Style System
+    slides:
+      - STYLE_SYSTEM_001
+      - STYLE_SYSTEM_002
+  - id: CONTROL_SYSTEM
+    title: Control System
+    slides:
+      - CONTROL_SYSTEM_001
+      - CONTROL_SYSTEM_002
+links:
+  references:
+    - from: STYLE_SYSTEM_001
+      to: CONTROL_SYSTEM_001
+      type: reference
+    - from: CONTROL_SYSTEM_002
+      to: STYLE_SYSTEM_002
+      type: interlude
+tokens: styles/tokens.yaml
+maps:
+  duplicate_reference: maps/duplicate_reference_map.yaml

--- a/docs/qps-slide-system/index.yaml
+++ b/docs/qps-slide-system/index.yaml
@@ -13,6 +13,7 @@ decks:
       - CONTROL_SYSTEM_001
       - CONTROL_SYSTEM_002
 links:
+  # Cross-deck links only. In-deck navigation (next/prev/home) is declared in each deck YAML.
   references:
     - from: STYLE_SYSTEM_001
       to: CONTROL_SYSTEM_001

--- a/docs/qps-slide-system/index.yaml
+++ b/docs/qps-slide-system/index.yaml
@@ -13,14 +13,40 @@ decks:
       - CONTROL_SYSTEM_001
       - CONTROL_SYSTEM_002
 links:
-  # Cross-deck links only. In-deck navigation (next/prev/home) is declared in each deck YAML.
-  references:
-    - from: STYLE_SYSTEM_001
-      to: CONTROL_SYSTEM_001
-      type: reference
-    - from: CONTROL_SYSTEM_002
-      to: STYLE_SYSTEM_002
-      type: interlude
+  # Full link index: in-deck navigation (next/prev/home) and cross-deck relations (reference/interlude).
+  # In-deck links are also declared inline in each deck YAML; this index is the authoritative combined view.
+  - id: STYLE_SYSTEM_001__next
+    from: STYLE_SYSTEM_001
+    to: STYLE_SYSTEM_002
+    type: next
+  - id: STYLE_SYSTEM_001__reference
+    from: STYLE_SYSTEM_001
+    to: CONTROL_SYSTEM_001
+    type: reference
+  - id: STYLE_SYSTEM_002__prev
+    from: STYLE_SYSTEM_002
+    to: STYLE_SYSTEM_001
+    type: prev
+  - id: STYLE_SYSTEM_002__home
+    from: STYLE_SYSTEM_002
+    to: home
+    type: home
+  - id: CONTROL_SYSTEM_001__next
+    from: CONTROL_SYSTEM_001
+    to: CONTROL_SYSTEM_002
+    type: next
+  - id: CONTROL_SYSTEM_001__reference
+    from: CONTROL_SYSTEM_001
+    to: STYLE_SYSTEM_001
+    type: reference
+  - id: CONTROL_SYSTEM_002__prev
+    from: CONTROL_SYSTEM_002
+    to: CONTROL_SYSTEM_001
+    type: prev
+  - id: CONTROL_SYSTEM_002__interlude
+    from: CONTROL_SYSTEM_002
+    to: STYLE_SYSTEM_002
+    type: interlude
 tokens: styles/tokens.yaml
 maps:
   duplicate_reference: maps/duplicate_reference_map.yaml

--- a/docs/qps-slide-system/maps/duplicate_reference_map.yaml
+++ b/docs/qps-slide-system/maps/duplicate_reference_map.yaml
@@ -1,0 +1,15 @@
+version: 0.5.0
+rules:
+  canonical_priority:
+    - master
+    - reference
+    - interlude
+map:
+  - canonical: STYLE_SYSTEM_001
+    duplicates: []
+    references:
+      - CONTROL_SYSTEM_001
+  - canonical: CONTROL_SYSTEM_002
+    duplicates: []
+    references:
+      - STYLE_SYSTEM_002

--- a/docs/qps-slide-system/maps/duplicate_reference_map.yaml
+++ b/docs/qps-slide-system/maps/duplicate_reference_map.yaml
@@ -2,14 +2,16 @@ version: 0.5.0
 rules:
   canonical_priority:
     - master
-    - reference
-    - interlude
 map:
   - canonical: STYLE_SYSTEM_001
     duplicates: []
     references:
       - CONTROL_SYSTEM_001
-  - canonical: CONTROL_SYSTEM_002
+  - canonical: CONTROL_SYSTEM_001
     duplicates: []
     references:
+      - STYLE_SYSTEM_001
+  - canonical: CONTROL_SYSTEM_002
+    duplicates: []
+    interludes:
       - STYLE_SYSTEM_002

--- a/docs/qps-slide-system/styles/tokens.yaml
+++ b/docs/qps-slide-system/styles/tokens.yaml
@@ -1,0 +1,19 @@
+colors:
+  bg: "#0f172a"
+  panel: "#111827"
+  text: "#e5e7eb"
+  accent: "#22d3ee"
+  warning: "#f59e0b"
+spacing:
+  xs: 4
+  sm: 8
+  md: 12
+  lg: 20
+typography:
+  font_stack: "Inter, Segoe UI, Arial, sans-serif"
+  h1: 30
+  h2: 22
+  body: 15
+emphasis:
+  canonical: "accent"
+  reference: "warning"


### PR DESCRIPTION
### Motivation

- Provide an HTML-first preview and navigation entry for the QPS master-slide system to enable lightweight review and walkthroughs via `index.html`.
- Seed the system with a minimal YAML index and per-deck slide sources so the render pipeline and linking semantics can be validated with real inputs.
- Capture style tokens and a canonical duplicate/reference mapping to support consistent visual theming and referential de-duplication in subsequent passes.

### Description

- Bumped system notes to `v0.5.0` in `CHANGELOG.md` and updated `README.md` to reflect the HTML render and YAML seed pass. 
- Added a runnable HTML preview `docs/qps-slide-system/index.html` implementing native section anchors and intra-document navigation for slides. 
- Added YAML index `docs/qps-slide-system/index.yaml` with `entrypoint: index.html` and deck listings for `STYLE_SYSTEM` and `CONTROL_SYSTEM`. 
- Added deck source files `docs/qps-slide-system/decks/style_system.yaml` and `docs/qps-slide-system/decks/control_system.yaml` with two master slides each and explicit link relations (`next`, `prev`, `reference`, `interlude`, `home`).
- Added style token source `docs/qps-slide-system/styles/tokens.yaml` and canonical map `docs/qps-slide-system/maps/duplicate_reference_map.yaml` to drive consistent styling and duplicate/reference rules.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0679265780832e98b37f31f3986439)