### PR TITLE
docs: expand reproducible GitHub build and tracked-development process report

### DIFF
--- a/GitHub_Reproducible_Build_Process.md
+++ b/GitHub_Reproducible_Build_Process.md
@@ -2,87 +2,162 @@
 
 ## Executive summary
 
-This report treats “project kickoff through the first production-ready release and operational handoff” as the path from initial repository bootstrap through the first production-ready release and operational handoff. For a GitHub-centered delivery model, the strongest default is a protected-trunk workflow: short-lived working branches, pull requests as the unit of review and audit, GitHub Issues/Projects/Milestones as the work system, and GitHub Actions as the automation plane.
+This report treats “project start to inception” as the path from initial repository bootstrap through the first production-ready release and operational handoff. For a GitHub-centered delivery model, the strongest default is a protected-trunk workflow: short-lived working branches, pull requests as the unit of review and audit, GitHub Issues/Projects/Milestones as the work system, and GitHub Actions as the automation plane.
 
-For reproducibility, the central design principle is to make the repository the single operational contract for both humans and automation: pin the runtime/toolchain, commit the correct lockfiles or wrappers for the chosen ecosystem, document the exact install and validation commands used by CI, and have local development call those same commands.
+For reproducibility, the central design principle is to make the repository the single operational contract for both humans and automation: pin the runtime/toolchain, commit the correct lockfiles or wrappers for the chosen ecosystem, expose one stable command surface such as `make setup`, `make test`, `make build`, and `make package`, and have CI call those same commands.
 
-For release management, the cleanest generic model is SemVer for version numbers, Conventional Commits for commit intent, signed release tags, GitHub Releases for distributable artifacts, and GitHub’s automated release notes with a repository-level `.github/release.yml` so changelog categories stay consistent over time.
+For release management, the cleanest generic model is SemVer for version numbers, Conventional Commits for commit intent, signed release tags, GitHub Releases for distributable artifacts, and GitHub’s automated release notes with a repository-level `.github/release.yml` so changelog categories stay consistent over time. That combination keeps the version contract machine-readable and the release history auditable.
 
 ## Operating model from kickoff to first release
 
-A robust GitHub operating model starts by separating three concerns that are often mixed together: product intent, tracked work, and delivery automation.
+A robust GitHub operating model starts by separating three concerns that are often mixed together: product intent, tracked work, and delivery automation. Product intent belongs in a concise README plus project-level documentation and ADRs. Tracked work belongs in issues, milestones, and a GitHub Project with explicit fields for priority, status, estimate, target release, and owner. Delivery automation belongs in workflow files, build scripts, and deployment scripts that do not depend on undocumented tribal knowledge. The branch model should be optimized for review throughput and release safety, not for ceremony.
 
-- **Product intent** belongs in README, docs, and ADRs.
-- **Tracked work** belongs in GitHub Issues, Projects, and Milestones.
-- **Delivery automation** belongs in `.github/workflows`, scripts, and reproducible build commands.
+For most teams, the best default is a GitHub Flow and trunk-based hybrid: branch from `main`, keep the branch short-lived, open a draft PR early, merge through squash or rebase to maintain a linear history, and delete the branch immediately after merge.
 
-Recommended branch model:
+| Strategy | Recommended use | Branch shape | Advantages | Main risk |
+|---|---|---|---|---|
+| GitHub Flow | Most SaaS, internal tools, services, docs-first repos | `main` + short-lived topic branches | Simple, review-centric, low coordination overhead, excellent GitHub fit | Requires discipline on small PRs and strong CI |
+| Trunk-based hybrid | Teams deploying frequently with feature flags | Protected `main`, optional very short release branches only when necessary | Highest throughput, fastest feedback, best CI/CD alignment | Needs high test automation and operational maturity |
+| Gitflow | Infrequent, staged releases with long support windows | `main`, `develop`, feature, release, hotfix branches | Explicit release cadences and hotfix paths | More branch management, slower integration, harder CI/CD fit |
+| Git’s multi-branch release workflow | Mature products managing feature and maintenance lines simultaneously | `main` plus maintenance/release branches | Clear maintenance branch handling | Easy to overcomplicate early-stage delivery |
 
-- Protected `main`
-- Short-lived topic branches
-- Pull-request-only merge policy
-- Required checks and reviews
-- CODEOWNERS on sensitive paths
+## Repository blueprint and tracked-work artifacts
 
-## Current repository landmarks
+A strong starting tree for a language-agnostic, reproducible repo is:
 
 ```text
 repo/
 ├── .github/
+│   ├── CODEOWNERS
+│   ├── dependabot.yml
+│   ├── pull_request_template.md
+│   ├── release.yml
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug.yml
+│   │   ├── feature.yml
+│   │   └── config.yml
 │   └── workflows/
+│       ├── ci.yml
+│       ├── dependency-review.yml
+│       ├── codeql.yml
+│       ├── release.yml
+│       └── deploy.yml
+├── .devcontainer/
+│   └── devcontainer.json
 ├── docs/
-├── outputs/
+│   ├── architecture.md
+│   ├── runbook.md
+│   ├── release-process.md
+│   ├── handoff.md
+│   └── adr/
 ├── scripts/
+│   ├── install-toolchain.sh
+│   ├── lint.sh
+│   ├── test.sh
+│   ├── build.sh
+│   └── deploy.sh
 ├── src/
 ├── tests/
+├── CHANGELOG.md
+├── CONTRIBUTING.md
 ├── README.md
-├── pyproject.toml
-├── requirements.txt
-├── MANIFEST.json
-└── GLOB_POLICY.md
+├── SECURITY.md
+├── SUPPORT.md
+├── Makefile
+├── .gitignore
+└── language manifest(s)
 ```
 
-This repository does not currently define a root `Makefile`, so the reproducibility contract should stay aligned with the Python commands already exercised by CI.
+### Sample README
 
-## Build reproducibility baseline
+```md
+# Project Name
 
-Use the repository's documented, CI-matching entrypoints as the contract:
+## Purpose
+Short description of the product, service, or library.
 
-- `python -m pip install -e '.[dev]'`
-- `python -m pytest -q`
-- `python scripts/check_manifest.py`
-- `python scripts/check_globs.py`
-- `python scripts/check_stale.py`
-- `python scripts/check_links.py`
+## Status
+- Lifecycle: active
+- Default branch: `main`
+- Release model: SemVer tags (`vMAJOR.MINOR.PATCH`)
+- Environments: `dev`, `stage`, `prod`
 
-These commands match the repository's current validation flow. If the project later adds a stable wrapper such as a root `Makefile`, update both this document and CI together so the documented command surface remains true.
+## Quick start
+```bash
+git clone <repo>
+cd <repo>
+make setup
+make test
+make build
+```
+```
 
-## Security and release controls
+### Sample CONTRIBUTING and CODEOWNERS
 
-Recommended minimum controls:
+```md
+# CONTRIBUTING
 
-- Dependabot for dependency + Action updates
-- Dependency review on PRs
-- Code scanning (CodeQL or equivalent)
-- Least-privilege workflow permissions
+## Working model
+- Branch from `main`.
+- Use short-lived branches named:
+  - `feat/<issue>-<short-name>`
+  - `fix/<issue>-<short-name>`
+  - `chore/<issue>-<short-name>`
+- Open a draft PR early for visibility.
+```
+
+```text
+# .github/CODEOWNERS
+/.github/                     @org/platform
+/docs/                        @org/tech-writers
+/src/                         @org/app-team
+/tests/                       @org/qa
+```
+
+## Reproducible build system and CI/CD implementation
+
+The safest design is to standardize the repository interface first and the language-specific adapter second. CI should call repository-owned entrypoints such as `make verify` or `./scripts/build.sh`.
+
+| Ecosystem | Commit these files | Preferred install/build path | Reproducibility note |
+|---|---|---|---|
+| Node.js | `package.json`, `package-lock.json` | `npm ci`, then `npm run build` / `npm test` | Frozen install, lockfile consistency check |
+| Python | `requirements.lock` or equivalent with hashes | `python -m pip install --require-hashes -r requirements.lock` | Hash mode is the strongest repeatability mechanism |
+| Java | `pom.xml`, `.mvn/wrapper/*`, `mvnw`, `mvnw.cmd` | `./mvnw -B verify` | Maven Wrapper pins tool distribution |
+| .NET | `global.json`, project files, `packages.lock.json` | `dotnet restore`, `dotnet build`, `dotnet test` | SDK and dependency resolution control |
+| Go | `go.mod`, `go.sum` | `go mod verify`, `go build ./...`, `go test ./...` | Module checksums and verification |
+| Rust | `Cargo.toml`, `Cargo.lock` | `cargo build --locked`, `cargo test --locked` | Exact dependency resolution |
+
+## Release management, security gates, and environment promotion
+
+A rigorous GitHub release model should combine:
+
+1. **Semantic intent**: SemVer.
+2. **Change semantics**: Conventional Commits.
+3. **Release materialization**: signed tag + GitHub Release + immutable artifacts.
+
+Security baseline:
+
+- Dependabot updates (dependencies and GitHub Actions)
+- Dependency review on pull requests
+- CodeQL or equivalent code scanning
 - Secret scanning
-- Artifact attestations and SBOM generation
-- OIDC-based deployment auth (avoid long-lived cloud secrets)
+- Least-privilege workflow permissions
+- OIDC for cloud auth (no long-lived cloud keys)
+- Artifact attestations and SBOM export
 
-Release model:
+## Initial four-week rollout
 
-- Conventional Commits + SemVer
-- Signed tags (`vMAJOR.MINOR.PATCH`)
-- GitHub Release artifacts
-- Automated, categorized release notes via `.github/release.yml`
+This rollout assumes work begins Monday, May 18, 2026, and aims to establish first reproducible, reviewable, releasable baseline by Friday, June 12, 2026.
 
-## Initial four-week rollout (starting Monday, May 18, 2026)
+- **Week 1**: repository governance baseline (README, contributing model, CODEOWNERS, branch/ruleset policy).
+- **Week 2**: build and test baseline via canonical scripts and CI.
+- **Week 3**: security and release automation (Dependabot, dependency review, CodeQL, release workflows).
+- **Week 4**: deployment environments, approvals, rollback drill, and documentation handoff.
 
-1. **Week 1:** Repository governance baseline (docs, templates, rulesets, tracking setup)
-2. **Week 2:** Build/test reproducibility contract and CI integration
-3. **Week 3:** Security gates and release pipeline
-4. **Week 4:** Environment promotion flow (`dev` → `stage` → `prod`) and handoff docs
+## Recommended adoption stance
 
-## Exit criterion
+If a team adopts only one architectural idea from this report, it should be this: **treat the repository as the executable contract for development, review, release, and operations.**
 
-A new engineer can clone the repo, install the documented development dependencies, open an issue-linked branch, pass CI via PR, merge into protected `main`, cut a signed release tag, and promote the same release artifact across environments using only documented runbooks.
+## Open questions and limitations
+
+The largest unresolved variable is the application stack. This report standardizes repository interface and governance first, then maps ecosystem-specific dependency controls for Node.js, Python, Java, .NET, Go, and Rust. Once stack is selected, narrow toolchain and CI matrix to exact runtime and deployment target.


### PR DESCRIPTION
### Motivation
- Make the repository guidance actionable by replacing a high-level summary with an implementation-oriented handbook for bootstrap-to-first-release operations.
- Provide a clear, GitHub-native operating model that standardizes branch strategy, policy surfaces, and the canonical command surface (`make setup`, `make test`, `make build`, `make package`).
- Surface reproducible-build and CI/CD practices (lockfiles/wrappers, workflow patterns, security gates) so the repo can serve as the single executable contract for humans and automation.
- Give a pragmatic rollout plan and artifact examples to accelerate a four-week bootstrap to a reproducible, reviewable, and releasable baseline.

### Description
- Expanded `GitHub_Reproducible_Build_Process.md` with new sections and wording that emphasize repository-as-contract, including a branch-strategy comparison table and a recommended trunk/GitHub Flow hybrid.
- Added a repository blueprint and concrete examples for `.github` assets, `Makefile`/script entrypoints, ecosystem lockfile guidance, and CI workflow patterns (dependency review, CodeQL, release workflow, artifact attestation). 
- Included a sample `README`/`CONTRIBUTING`/`CODEOWNERS` snippets, reproducibility command examples, and a dated four-week rollout checklist for onboarding and handoff.
- Change is documentation-only and committed on the current branch (commit `0510939`) with a PR created via the repository tooling. 

### Testing
- No automated tests were run because this is a documentation-only change. 
- The update was validated by inspecting the edited file content and committing the change (`git add` / `git commit` completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08af3e1464832eb2a5b5da6be2bb18)