### PR TITLE
Pass template settings through pandoc conversions (guard missing template)

### DIFF
--- a/slides/qplant_sckcen_template.py
+++ b/slides/qplant_sckcen_template.py
@@ -148,7 +148,7 @@ def convert_markdown_bundle(
                 str(target),
             ]
 
-            if fmt == "pptx":
+            if fmt == "pptx" and settings.template_path.exists():
                 args.extend(["--reference-doc", str(settings.template_path)])
 
             if settings.partner_logo:


### PR DESCRIPTION
## Summary
- propagate template settings into pandoc builds so CLI options like --template, --partner-logo, and --strict-links are honored
- attach template reference doc and metadata flags for partner logos, base URLs, and strict link validation when rendering decks
- skip adding the PPTX reference-doc flag when the template file is missing so default builds continue to succeed

## Testing
- python -m compileall slides src

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_692483dfe744832ebf70bd7af920b597)