### PR TITLE
Add QCell v0.6.2 handoff package and view-policy assets; update docs and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ GISTAU/sources/master/*.pdf
 !GISTAU/sources/master/source_manifest.yaml
 !GISTAU/sources/master/checksums.sha256
 GISTAU/derived/tmp/
+
+# Generated handoff bundles (binary)
+handoff/*_handover_bundle.zip
+handoff/*_handover_bundle.tar.gz

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,18 +117,18 @@
       <h2>QCell v0.6.2 Regression Correction Package</h2>
       <p>Temperature and pressure are now explicitly separated: temperature is the primary analysis mode; pressure is secondary diagnostic only.</p>
       <ul>
-        <li><a href="../svg/temperature_analysis_v0_6_2.svg">Temperature analysis SVG (v0.6.2)</a></li>
-        <li><a href="../svg/pressure_diagnostic_v0_6_2.svg">Pressure diagnostic SVG (v0.6.2)</a></li>
-        <li><a href="../src/qcell_view_policy_v0_6_2.yaml">SSOT view policy YAML (v0.6.2)</a></li>
-        <li><a href="../handoff/README.md">Handoff bundle rebuild instructions (binary outputs excluded from Git)</a></li>
+        <li><a href="https://github.com/GBOGEB/CODEX/blob/main/svg/temperature_analysis_v0_6_2.svg">Temperature analysis SVG (v0.6.2)</a></li>
+        <li><a href="https://github.com/GBOGEB/CODEX/blob/main/svg/pressure_diagnostic_v0_6_2.svg">Pressure diagnostic SVG (v0.6.2)</a></li>
+        <li><a href="https://github.com/GBOGEB/CODEX/blob/main/src/qcell_view_policy_v0_6_2.yaml">SSOT view policy YAML (v0.6.2)</a></li>
+        <li><a href="https://github.com/GBOGEB/CODEX/blob/main/handoff/README.md">Handoff bundle rebuild instructions (binary outputs excluded from Git)</a></li>
       </ul>
       <details>
         <summary>Layer toggle demo (explicit combined mode)</summary>
         <label><input type="checkbox" id="tempToggle" checked> Temperature layer</label>
         <label style="margin-left:12px;"><input type="checkbox" id="pressToggle" checked> Pressure layer</label>
         <div style="position:relative; margin-top:12px; border:1px solid #4b5563; border-radius:8px; overflow:hidden; max-width:100%;">
-          <img id="tempLayer" src="../svg/temperature_analysis_v0_6_2.svg" alt="Temperature primary layer" style="display:block; width:100%;">
-          <img id="pressLayer" src="../svg/pressure_diagnostic_v0_6_2.svg" alt="Pressure diagnostic layer" style="display:block; width:100%; margin-top:8px;">
+          <img id="tempLayer" src="https://raw.githubusercontent.com/GBOGEB/CODEX/main/svg/temperature_analysis_v0_6_2.svg" alt="Temperature primary layer" style="display:block; width:100%;">
+          <img id="pressLayer" src="https://raw.githubusercontent.com/GBOGEB/CODEX/main/svg/pressure_diagnostic_v0_6_2.svg" alt="Pressure diagnostic layer" style="display:block; width:100%; margin-top:8px;">
         </div>
       </details>
     </section>

--- a/handoff/README.md
+++ b/handoff/README.md
@@ -1,0 +1,20 @@
+# Handoff Packaging Notes
+
+This repository keeps handoff contents in text/source form to remain PR-reviewable on platforms that do not support binary diff rendering.
+
+## Included (tracked)
+- `handoff/v0_6_2/` package directory (HTML, SVG, YAML)
+
+## Excluded (generated locally)
+- `handoff/v0_6_2_handover_bundle.zip`
+- `handoff/v0_6_2_handover_bundle.tar.gz`
+
+## Rebuild bundles
+From repository root:
+
+```bash
+(cd handoff && zip -r v0_6_2_handover_bundle.zip v0_6_2)
+(cd handoff && tar -czf v0_6_2_handover_bundle.tar.gz v0_6_2)
+```
+
+These commands are deterministic for package contents and should be used only for distribution artifacts, not for source control.

--- a/handoff/README.md
+++ b/handoff/README.md
@@ -17,4 +17,4 @@ From repository root:
 (cd handoff && tar -czf v0_6_2_handover_bundle.tar.gz v0_6_2)
 ```
 
-These commands are deterministic for package contents and should be used only for distribution artifacts, not for source control.
+These commands rebuild the same package contents, but the resulting archives are not byte-reproducible by default because `zip` and `tar` may record varying metadata such as timestamps, ownership, and file order. Use them only for local/distribution artifacts, not for source control or reproducible release packaging.

--- a/handoff/v0_6_2/index.html
+++ b/handoff/v0_6_2/index.html
@@ -117,17 +117,17 @@
       <h2>QCell v0.6.2 Regression Correction Package</h2>
       <p>Temperature and pressure are now explicitly separated: temperature is the primary analysis mode; pressure is secondary diagnostic only.</p>
       <ul>
-        <li><a href="../svg/temperature_analysis_v0_6_2.svg">Temperature analysis SVG (v0.6.2)</a></li>
-        <li><a href="../svg/pressure_diagnostic_v0_6_2.svg">Pressure diagnostic SVG (v0.6.2)</a></li>
-        <li><a href="../src/qcell_view_policy_v0_6_2.yaml">SSOT view policy YAML (v0.6.2)</a></li>
+        <li><a href="temperature_analysis_v0_6_2.svg">Temperature analysis SVG (v0.6.2)</a></li>
+        <li><a href="pressure_diagnostic_v0_6_2.svg">Pressure diagnostic SVG (v0.6.2)</a></li>
+        <li><a href="qcell_view_policy_v0_6_2.yaml">SSOT view policy YAML (v0.6.2)</a></li>
       </ul>
       <details>
         <summary>Layer toggle demo (explicit combined mode)</summary>
         <label><input type="checkbox" id="tempToggle" checked> Temperature layer</label>
         <label style="margin-left:12px;"><input type="checkbox" id="pressToggle" checked> Pressure layer</label>
         <div style="position:relative; margin-top:12px; border:1px solid #4b5563; border-radius:8px; overflow:hidden; max-width:100%;">
-          <img id="tempLayer" src="../svg/temperature_analysis_v0_6_2.svg" alt="Temperature primary layer" style="display:block; width:100%;">
-          <img id="pressLayer" src="../svg/pressure_diagnostic_v0_6_2.svg" alt="Pressure diagnostic layer" style="display:block; width:100%; margin-top:8px;">
+          <img id="tempLayer" src="temperature_analysis_v0_6_2.svg" alt="Temperature primary layer" style="display:block; width:100%;">
+          <img id="pressLayer" src="pressure_diagnostic_v0_6_2.svg" alt="Pressure diagnostic layer" style="display:block; width:100%; margin-top:8px;">
         </div>
       </details>
     </section>

--- a/handoff/v0_6_2/index.html
+++ b/handoff/v0_6_2/index.html
@@ -22,17 +22,18 @@
 <body>
   <h1>Q Engineering Tools Portal</h1>
   <p>Canonical GitHub Pages entry point for curated engineering outputs.</p>
+  <p class="muted">This handoff package includes only package-local assets. The broader portal pages below are not bundled in <code>handoff/v0_6_2/</code>, so they are listed for reference instead of as offline links.</p>
   <ul>
-    <li><a href="engineering_portal.html">Engineering Portal (Enhanced Entry)</a></li>
-    <li><a href="dashboard.html">Dashboard</a></li>
-    <li><a href="plots/index.html">Plots</a></li>
-    <li><a href="handover.html">Handover</a></li>
-    <li><a href="verification.html">Verification</a></li>
-    <li><a href="regression.html">Regression</a></li>
-    <li><a href="traceability.html">Traceability</a></li>
-    <li><a href="manifest.html">Manifest</a></li>
-    <li><a href="knowledge_transfer_slides.html">Knowledge Transfer Slides</a></li>
-    <li><a href="knowledge_transfer.html">Knowledge Transfer Plan</a></li>
+    <li>Engineering Portal (Enhanced Entry) <span class="muted">— not included in this handoff package</span></li>
+    <li>Dashboard <span class="muted">— not included in this handoff package</span></li>
+    <li>Plots <span class="muted">— not included in this handoff package</span></li>
+    <li>Handover <span class="muted">— not included in this handoff package</span></li>
+    <li>Verification <span class="muted">— not included in this handoff package</span></li>
+    <li>Regression <span class="muted">— not included in this handoff package</span></li>
+    <li>Traceability <span class="muted">— not included in this handoff package</span></li>
+    <li>Manifest <span class="muted">— not included in this handoff package</span></li>
+    <li>Knowledge Transfer Slides <span class="muted">— not included in this handoff package</span></li>
+    <li>Knowledge Transfer Plan <span class="muted">— not included in this handoff package</span></li>
   </ul>
   <main>
     <section class="hero">

--- a/handoff/v0_6_2/index.html
+++ b/handoff/v0_6_2/index.html
@@ -120,7 +120,6 @@
         <li><a href="../svg/temperature_analysis_v0_6_2.svg">Temperature analysis SVG (v0.6.2)</a></li>
         <li><a href="../svg/pressure_diagnostic_v0_6_2.svg">Pressure diagnostic SVG (v0.6.2)</a></li>
         <li><a href="../src/qcell_view_policy_v0_6_2.yaml">SSOT view policy YAML (v0.6.2)</a></li>
-        <li><a href="../handoff/README.md">Handoff bundle rebuild instructions (binary outputs excluded from Git)</a></li>
       </ul>
       <details>
         <summary>Layer toggle demo (explicit combined mode)</summary>

--- a/handoff/v0_6_2/pressure_diagnostic_v0_6_2.svg
+++ b/handoff/v0_6_2/pressure_diagnostic_v0_6_2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+  <title id="title">Pressure Diagnostic View v0.6.2</title>
+  <desc id="desc">Secondary pressure-only diagnostic layer with independent palette and no temperature colour reuse.</desc>
+  <defs>
+    <linearGradient id="pressure" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#7dd3fc"/>
+      <stop offset="35%" stop-color="#38bdf8"/>
+      <stop offset="60%" stop-color="#6b7280"/>
+      <stop offset="100%" stop-color="#1f2937"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="720" fill="#111827"/>
+  <text x="40" y="55" fill="#e5e7eb" font-size="30" font-family="Arial">QCell Pressure Diagnostic View (v0.6.2)</text>
+  <rect x="50" y="120" width="1100" height="300" fill="url(#pressure)" stroke="#e5e7eb" stroke-width="2"/>
+  <g fill="#d1d5db" font-family="Arial" font-size="20">
+    <text x="60" y="470">Low pressure: blue/cyan diagnostic zone</text>
+    <text x="60" y="505">Mid pressure: transition to neutral purple-grey</text>
+    <text x="60" y="540">High pressure: dark diagnostic zone</text>
+  </g>
+  <text x="40" y="615" fill="#fca5a5" font-size="18" font-family="Arial">Constraint: no cryogenic thermal colours in pressure view.</text>
+  <text x="40" y="660" fill="#9ca3af" font-size="16" font-family="Arial">Use only as secondary overlay or independent diagnostic mode.</text>
+</svg>

--- a/handoff/v0_6_2/qcell_view_policy_v0_6_2.yaml
+++ b/handoff/v0_6_2/qcell_view_policy_v0_6_2.yaml
@@ -1,0 +1,32 @@
+version: v0.6.2
+name: qcell_view_policy
+regression_correction:
+  issue: pressure_temperature_palette_collision
+  resolution: independent_views_and_palettes
+
+views:
+  temperature_analysis:
+    role: primary
+    palette: cryogenic_dedicated
+    thresholds_k: [2, 4, 30, 50, 60, 77]
+    warm_extension_k: [77, 300]
+    semantics: thermal_physics_primary
+  pressure_diagnostic:
+    role: secondary
+    palette: diagnostic_independent
+    low_zone: blue_cyan_or_purple_grey
+    high_zone: dark_diagnostic
+    semantics: operational_diagnostic_only
+
+combined_view:
+  allowed: true
+  requires_explicit_toggle: true
+  separated_legends: true
+  removable_layers_live: true
+  semantic_guardrail: prevent_mixed_interpretation
+
+continuation:
+  preserve_governance_baseline: pr_38
+  preserve_metadata: [A_B, D_E]
+  preserve_parasitic_sign_reversal_logic: true
+  next_target: v0.7.0_svg_grammar_style_proof

--- a/handoff/v0_6_2/temperature_analysis_v0_6_2.svg
+++ b/handoff/v0_6_2/temperature_analysis_v0_6_2.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+  <title id="title">Temperature Analysis v0.6.2</title>
+  <desc id="desc">Primary cryogenic thermal analysis view with dedicated 2 K to 77 K scale and separate warm range to 300 K.</desc>
+  <defs>
+    <linearGradient id="cryo" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#14213d"/>
+      <stop offset="15%" stop-color="#1d4e89"/>
+      <stop offset="35%" stop-color="#1f7a8c"/>
+      <stop offset="55%" stop-color="#38b000"/>
+      <stop offset="75%" stop-color="#ffb703"/>
+      <stop offset="100%" stop-color="#fb8500"/>
+    </linearGradient>
+    <linearGradient id="warm" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="50%" stop-color="#ef4444"/>
+      <stop offset="100%" stop-color="#7f1d1d"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="720" fill="#0b1020"/>
+  <text x="40" y="55" fill="#e5e7eb" font-size="30" font-family="Arial">QCell Thermal Analysis — Temperature Primary (v0.6.2)</text>
+  <rect x="50" y="100" width="1100" height="340" fill="url(#cryo)" stroke="#e5e7eb" stroke-width="2"/>
+  <text x="60" y="470" fill="#e5e7eb" font-size="22" font-family="Arial">Cryogenic temperature scale (2–77 K):</text>
+  <g fill="#d1d5db" font-family="Arial" font-size="18">
+    <text x="60" y="505">2 K</text><text x="180" y="505">4 K</text><text x="320" y="505">30 K</text><text x="470" y="505">50 K</text><text x="630" y="505">60 K</text><text x="810" y="505">77 K</text>
+  </g>
+  <rect x="50" y="540" width="1100" height="60" fill="url(#warm)" stroke="#e5e7eb" stroke-width="2"/>
+  <text x="60" y="635" fill="#e5e7eb" font-size="20" font-family="Arial">Warm extension (separate semantic band): 77–300 K</text>
+  <text x="40" y="690" fill="#9ca3af" font-size="16" font-family="Arial">Policy: pressure colours are excluded from this layer to preserve thermal grammar.</text>
+</svg>

--- a/src/qcell_view_policy_v0_6_2.yaml
+++ b/src/qcell_view_policy_v0_6_2.yaml
@@ -1,0 +1,32 @@
+version: v0.6.2
+name: qcell_view_policy
+regression_correction:
+  issue: pressure_temperature_palette_collision
+  resolution: independent_views_and_palettes
+
+views:
+  temperature_analysis:
+    role: primary
+    palette: cryogenic_dedicated
+    thresholds_k: [2, 4, 30, 50, 60, 77]
+    warm_extension_k: [77, 300]
+    semantics: thermal_physics_primary
+  pressure_diagnostic:
+    role: secondary
+    palette: diagnostic_independent
+    low_zone: blue_cyan_or_purple_grey
+    high_zone: dark_diagnostic
+    semantics: operational_diagnostic_only
+
+combined_view:
+  allowed: true
+  requires_explicit_toggle: true
+  separated_legends: true
+  removable_layers_live: true
+  semantic_guardrail: prevent_mixed_interpretation
+
+continuation:
+  preserve_governance_baseline: pr_38
+  preserve_metadata: [A_B, D_E]
+  preserve_parasitic_sign_reversal_logic: true
+  next_target: v0.7.0_svg_grammar_style_proof

--- a/svg/pressure_diagnostic_v0_6_2.svg
+++ b/svg/pressure_diagnostic_v0_6_2.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+  <title id="title">Pressure Diagnostic View v0.6.2</title>
+  <desc id="desc">Secondary pressure-only diagnostic layer with independent palette and no temperature colour reuse.</desc>
+  <defs>
+    <linearGradient id="pressure" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#7dd3fc"/>
+      <stop offset="35%" stop-color="#38bdf8"/>
+      <stop offset="60%" stop-color="#6b7280"/>
+      <stop offset="100%" stop-color="#1f2937"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="720" fill="#111827"/>
+  <text x="40" y="55" fill="#e5e7eb" font-size="30" font-family="Arial">QCell Pressure Diagnostic View (v0.6.2)</text>
+  <rect x="50" y="120" width="1100" height="300" fill="url(#pressure)" stroke="#e5e7eb" stroke-width="2"/>
+  <g fill="#d1d5db" font-family="Arial" font-size="20">
+    <text x="60" y="470">Low pressure: blue/cyan diagnostic zone</text>
+    <text x="60" y="505">Mid pressure: transition to neutral purple-grey</text>
+    <text x="60" y="540">High pressure: dark diagnostic zone</text>
+  </g>
+  <text x="40" y="615" fill="#fca5a5" font-size="18" font-family="Arial">Constraint: no cryogenic thermal colours in pressure view.</text>
+  <text x="40" y="660" fill="#9ca3af" font-size="16" font-family="Arial">Use only as secondary overlay or independent diagnostic mode.</text>
+</svg>

--- a/svg/temperature_analysis_v0_6_2.svg
+++ b/svg/temperature_analysis_v0_6_2.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+  <title id="title">Temperature Analysis v0.6.2</title>
+  <desc id="desc">Primary cryogenic thermal analysis view with dedicated 2 K to 77 K scale and separate warm range to 300 K.</desc>
+  <defs>
+    <linearGradient id="cryo" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#14213d"/>
+      <stop offset="15%" stop-color="#1d4e89"/>
+      <stop offset="35%" stop-color="#1f7a8c"/>
+      <stop offset="55%" stop-color="#38b000"/>
+      <stop offset="75%" stop-color="#ffb703"/>
+      <stop offset="100%" stop-color="#fb8500"/>
+    </linearGradient>
+    <linearGradient id="warm" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="50%" stop-color="#ef4444"/>
+      <stop offset="100%" stop-color="#7f1d1d"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="720" fill="#0b1020"/>
+  <text x="40" y="55" fill="#e5e7eb" font-size="30" font-family="Arial">QCell Thermal Analysis — Temperature Primary (v0.6.2)</text>
+  <rect x="50" y="100" width="1100" height="340" fill="url(#cryo)" stroke="#e5e7eb" stroke-width="2"/>
+  <text x="60" y="470" fill="#e5e7eb" font-size="22" font-family="Arial">Cryogenic temperature scale (2–77 K):</text>
+  <g fill="#d1d5db" font-family="Arial" font-size="18">
+    <text x="60" y="505">2 K</text><text x="180" y="505">4 K</text><text x="320" y="505">30 K</text><text x="470" y="505">50 K</text><text x="630" y="505">60 K</text><text x="810" y="505">77 K</text>
+  </g>
+  <rect x="50" y="540" width="1100" height="60" fill="url(#warm)" stroke="#e5e7eb" stroke-width="2"/>
+  <text x="60" y="635" fill="#e5e7eb" font-size="20" font-family="Arial">Warm extension (separate semantic band): 77–300 K</text>
+  <text x="40" y="690" fill="#9ca3af" font-size="16" font-family="Arial">Policy: pressure colours are excluded from this layer to preserve thermal grammar.</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Deliver a QCell v0.6.2 regression-correction handoff package that separates temperature (primary) and pressure (secondary) views to avoid palette collisions.
- Make the handoff content reviewable in source form while excluding generated binary bundles from version control.

### Description
- Add a new handoff package under `handoff/v0_6_2/` including `index.html`, `temperature_analysis_v0_6_2.svg`, `pressure_diagnostic_v0_6_2.svg`, and `qcell_view_policy_v0_6_2.yaml` to capture the correction artifacts.
- Add matching assets in the top-level `svg/` folder and a canonical policy YAML in `src/` as `qcell_view_policy_v0_6_2.yaml` for integration with existing tooling.
- Update `docs/index.html` to document the package and include a small layer-toggle demo with inline JavaScript to show temperature/pressure layer toggling.
- Add `handoff/README.md` with deterministic bundle rebuild instructions and update `.gitignore` to exclude `handoff/*_handover_bundle.zip` and `handoff/*_handover_bundle.tar.gz` while keeping handoff source tracked.

### Testing
- No automated tests were run as part of this content-only change and no code behavior was modified by the change.
- The change consists of added static assets, documentation, and ignore rules and does not alter existing test suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08ee0caa38832ea7b6b6177e981140)