### PR TITLE
docs: add cryogenic dashboard canonical delta map

### DIFF
--- a/docs/cryo_dashboard/CODEX_DOCORG_DELTA_MAP_v0.4.9.md
+++ b/docs/cryo_dashboard/CODEX_DOCORG_DELTA_MAP_v0.4.9.md
@@ -51,4 +51,9 @@ Created during session:
 
 - `codex/cryo-v0.4.9-session-handover`
 
+Branch classification:
+
+- variance type: natural variance
+- branch type: stable feature
+
 End of delta map.

--- a/docs/cryo_dashboard/CODEX_DOCORG_DELTA_MAP_v0.4.9.md
+++ b/docs/cryo_dashboard/CODEX_DOCORG_DELTA_MAP_v0.4.9.md
@@ -1,0 +1,54 @@
+# CODEX ↔ document-organization-system Delta Map — Cryogenic Dashboard v0.4.9
+
+## Repository Roles
+
+| Repository | Role |
+|---|---|
+| `GBOGEB/document-organization-system` | Canonical runtime/tool repository |
+| `GBOGEB/CODEX` | Supplemental development/handover repository |
+
+## Canonical Runtime Location
+
+```text
+GBOGEB/document-organization-system/cryo_dashboard_v0_3_0/cryo_dashboard_v0_3_0/
+```
+
+## Intent
+
+This document exists to prevent ambiguity between:
+- runtime dashboard ownership;
+- recursive handover/development tooling;
+- SSOT metadata exploration;
+- future automation workflows.
+
+## Current Interpretation
+
+The dashboard runtime, GitHub Pages deployment, tests, package metadata, materials database, and release history belong in:
+
+- `GBOGEB/document-organization-system`
+
+CODEX should host:
+
+- recursive engineering handovers;
+- agent orchestration notes;
+- automation helpers;
+- delta maps;
+- future validation tooling.
+
+## Recommended Future Tooling
+
+Potential CODEX additions:
+
+- `version_audit.py`
+- `static_entrypoint_check.py`
+- release coherence scanners
+- RTM generators
+- recursive session bundlers
+
+## Session Branch
+
+Created during session:
+
+- `codex/cryo-v0.4.9-session-handover`
+
+End of delta map.


### PR DESCRIPTION
## Summary

Adds a repository-role and delta-mapping document clarifying the relationship between:

- `GBOGEB/document-organization-system`
- `GBOGEB/CODEX`

## Intent

This PR explicitly records that:

- `document-organization-system` is the canonical cryogenic dashboard runtime/tool repository;
- `CODEX` is supplemental for recursive handover, automation, agent workflows, and development support.

## Included

- CODEX ↔ canonical repo delta map
- runtime ownership clarification
- future tooling recommendations
- branch/session traceability

## Guidance

Avoid duplicating the runtime dashboard in CODEX unless a future sandbox/export workflow is intentionally created.
