### PR TITLE
PR-C: tuple calculation modularization and fallback tests

### DIFF
--- a/src/gistau_ch15/calculations/compressor.py
+++ b/src/gistau_ch15/calculations/compressor.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gistau_ch15.properties.base import PropertyBackend
+
+
+@dataclass
+class CompressorResult:
+    inlet_pressure_kpa: float
+    outlet_pressure_kpa: float
+    inlet_temperature_k: float
+    outlet_temperature_k: float
+    shaft_power_w: float
+    isothermal_efficiency: float
+
+
+def calculate_compressor(
+    backend: PropertyBackend,
+    fluid: str,
+    p1_kpa: float,
+    t1_k: float,
+    p2_kpa: float,
+    mdot_kg_s: float,
+    eta_isentropic: float,
+) -> CompressorResult:
+    """Fallback compressor calculation.
+
+    This implementation intentionally remains simple until
+    REFPROP/HEPAK integration is available.
+    """
+
+    st1 = backend.state_pt(fluid, p1_kpa, t1_k)
+
+    pressure_ratio = max(p2_kpa / max(p1_kpa, 1e-9), 1.0)
+    t2_k = t1_k * pressure_ratio ** 0.28
+
+    st2 = backend.state_pt(fluid, p2_kpa, t2_k)
+
+    dh = max(st2.enthalpy_j_kg - st1.enthalpy_j_kg, 0.0)
+    power = mdot_kg_s * dh / max(eta_isentropic, 1e-9)
+
+    return CompressorResult(
+        inlet_pressure_kpa=p1_kpa,
+        outlet_pressure_kpa=p2_kpa,
+        inlet_temperature_k=t1_k,
+        outlet_temperature_k=t2_k,
+        shaft_power_w=power,
+        isothermal_efficiency=eta_isentropic,
+    )

--- a/src/gistau_ch15/calculations/compressor.py
+++ b/src/gistau_ch15/calculations/compressor.py
@@ -5,6 +5,9 @@ from math import log
 
 from gistau_ch15.properties.base import PropertyBackend
 
+KPA_TO_PA = 1000.0
+ISENTROPIC_TEMPERATURE_EXPONENT = 0.28
+
 
 @dataclass
 class CompressorResult:
@@ -50,17 +53,23 @@ def calculate_compressor(
     st1 = backend.state_pt(fluid, p1_kpa, t1_k)
 
     pressure_ratio = p2_kpa / p1_kpa
-    t2_k = t1_k * pressure_ratio**0.28
+    t2_k = t1_k * pressure_ratio**ISENTROPIC_TEMPERATURE_EXPONENT
 
     st2 = backend.state_pt(fluid, p2_kpa, t2_k)
 
-    gas_constant = (st1.pressure_kpa * 1000.0) / max(st1.density_kg_m3 * st1.temperature_k, 1e-9)
+    denominator = st1.density_kg_m3 * st1.temperature_k
+    if denominator <= 0.0:
+        raise ValueError("backend returned non-physical inlet state for gas constant calculation")
+
+    gas_constant = (st1.pressure_kpa * KPA_TO_PA) / denominator
     isothermal_specific_work_j_kg = gas_constant * t1_k * log(pressure_ratio)
     power = mdot_kg_s * isothermal_specific_work_j_kg / eta_isothermal
     isentropic_power = None
 
     if eta_isentropic is not None:
-        dh = max(st2.enthalpy_j_kg - st1.enthalpy_j_kg, 0.0)
+        dh = st2.enthalpy_j_kg - st1.enthalpy_j_kg
+        if dh <= 0.0:
+            raise ValueError("backend returned non-physical enthalpy rise for compressor")
         isentropic_power = mdot_kg_s * dh / eta_isentropic
 
     return CompressorResult(

--- a/src/gistau_ch15/calculations/compressor.py
+++ b/src/gistau_ch15/calculations/compressor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import log
 
 from gistau_ch15.properties.base import PropertyBackend
 
@@ -12,7 +13,9 @@ class CompressorResult:
     inlet_temperature_k: float
     outlet_temperature_k: float
     shaft_power_w: float
+    isentropic_shaft_power_w: float | None
     isothermal_efficiency: float
+    isentropic_efficiency: float | None
 
 
 def calculate_compressor(
@@ -22,7 +25,8 @@ def calculate_compressor(
     t1_k: float,
     p2_kpa: float,
     mdot_kg_s: float,
-    eta_isentropic: float,
+    eta_isothermal: float = 0.5,
+    eta_isentropic: float | None = 0.5,
 ) -> CompressorResult:
     """Fallback compressor calculation.
 
@@ -30,15 +34,34 @@ def calculate_compressor(
     REFPROP/HEPAK integration is available.
     """
 
+    if p1_kpa <= 0.0:
+        raise ValueError("p1_kpa must be positive")
+    if p2_kpa <= p1_kpa:
+        raise ValueError("p2_kpa must be greater than p1_kpa")
+    if t1_k <= 0.0:
+        raise ValueError("t1_k must be positive")
+    if mdot_kg_s <= 0.0:
+        raise ValueError("mdot_kg_s must be positive")
+    if not (0.0 < eta_isothermal <= 1.0):
+        raise ValueError("eta_isothermal must satisfy 0 < eta_isothermal <= 1")
+    if eta_isentropic is not None and not (0.0 < eta_isentropic <= 1.0):
+        raise ValueError("eta_isentropic must satisfy 0 < eta_isentropic <= 1")
+
     st1 = backend.state_pt(fluid, p1_kpa, t1_k)
 
-    pressure_ratio = max(p2_kpa / max(p1_kpa, 1e-9), 1.0)
-    t2_k = t1_k * pressure_ratio ** 0.28
+    pressure_ratio = p2_kpa / p1_kpa
+    t2_k = t1_k * pressure_ratio**0.28
 
     st2 = backend.state_pt(fluid, p2_kpa, t2_k)
 
-    dh = max(st2.enthalpy_j_kg - st1.enthalpy_j_kg, 0.0)
-    power = mdot_kg_s * dh / max(eta_isentropic, 1e-9)
+    gas_constant = (st1.pressure_kpa * 1000.0) / max(st1.density_kg_m3 * st1.temperature_k, 1e-9)
+    isothermal_specific_work_j_kg = gas_constant * t1_k * log(pressure_ratio)
+    power = mdot_kg_s * isothermal_specific_work_j_kg / eta_isothermal
+    isentropic_power = None
+
+    if eta_isentropic is not None:
+        dh = max(st2.enthalpy_j_kg - st1.enthalpy_j_kg, 0.0)
+        isentropic_power = mdot_kg_s * dh / eta_isentropic
 
     return CompressorResult(
         inlet_pressure_kpa=p1_kpa,
@@ -46,5 +69,7 @@ def calculate_compressor(
         inlet_temperature_k=t1_k,
         outlet_temperature_k=t2_k,
         shaft_power_w=power,
-        isothermal_efficiency=eta_isentropic,
+        isentropic_shaft_power_w=isentropic_power,
+        isothermal_efficiency=eta_isothermal,
+        isentropic_efficiency=eta_isentropic,
     )

--- a/tests/gistau_ch15/test_fallback_engine.py
+++ b/tests/gistau_ch15/test_fallback_engine.py
@@ -1,0 +1,29 @@
+from gistau_ch15.properties.fallback_helium import FallbackHeliumBackend
+from gistau_ch15.calculations.compressor import calculate_compressor
+
+
+def test_fallback_backend_state_pt():
+    backend = FallbackHeliumBackend()
+    st = backend.state_pt('helium', 101.3, 300.0)
+
+    assert st.temperature_k == 300.0
+    assert st.pressure_kpa == 101.3
+    assert st.density_kg_m3 > 0.0
+
+
+def test_compressor_tuple_positive_power():
+    backend = FallbackHeliumBackend()
+
+    result = calculate_compressor(
+        backend=backend,
+        fluid='helium',
+        p1_kpa=101.3,
+        t1_k=300.0,
+        p2_kpa=1200.0,
+        mdot_kg_s=0.2,
+        eta_isentropic=0.75,
+    )
+
+    assert result.shaft_power_w > 0.0
+    assert result.outlet_pressure_kpa > result.inlet_pressure_kpa
+    assert result.outlet_temperature_k > result.inlet_temperature_k

--- a/tests/gistau_ch15/test_fallback_engine.py
+++ b/tests/gistau_ch15/test_fallback_engine.py
@@ -1,3 +1,5 @@
+import pytest
+
 from gistau_ch15.properties.fallback_helium import FallbackHeliumBackend
 from gistau_ch15.calculations.compressor import calculate_compressor
 
@@ -21,9 +23,75 @@ def test_compressor_tuple_positive_power():
         t1_k=300.0,
         p2_kpa=1200.0,
         mdot_kg_s=0.2,
+        eta_isothermal=0.75,
         eta_isentropic=0.75,
     )
 
     assert result.shaft_power_w > 0.0
+    assert result.isentropic_shaft_power_w is not None
+    assert result.isentropic_shaft_power_w > 0.0
     assert result.outlet_pressure_kpa > result.inlet_pressure_kpa
     assert result.outlet_temperature_k > result.inlet_temperature_k
+
+
+def test_compressor_defaults_to_half_efficiencies():
+    backend = FallbackHeliumBackend()
+
+    result = calculate_compressor(
+        backend=backend,
+        fluid='helium',
+        p1_kpa=101.3,
+        t1_k=300.0,
+        p2_kpa=500.0,
+        mdot_kg_s=0.1,
+    )
+
+    assert result.isothermal_efficiency == 0.5
+    assert result.isentropic_efficiency == 0.5
+
+
+def test_compressor_isentropic_output_can_be_disabled():
+    backend = FallbackHeliumBackend()
+
+    result = calculate_compressor(
+        backend=backend,
+        fluid='helium',
+        p1_kpa=101.3,
+        t1_k=300.0,
+        p2_kpa=600.0,
+        mdot_kg_s=0.1,
+        eta_isentropic=None,
+    )
+
+    assert result.shaft_power_w > 0.0
+    assert result.isentropic_shaft_power_w is None
+    assert result.isentropic_efficiency is None
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"p1_kpa": 0.0},
+        {"p2_kpa": 100.0},
+        {"t1_k": 0.0},
+        {"mdot_kg_s": 0.0},
+        {"eta_isothermal": 0.0},
+        {"eta_isentropic": 1.1},
+    ],
+)
+def test_compressor_invalid_inputs_raise_value_error(kwargs):
+    backend = FallbackHeliumBackend()
+    args = {
+        "backend": backend,
+        "fluid": "helium",
+        "p1_kpa": 101.3,
+        "t1_k": 300.0,
+        "p2_kpa": 600.0,
+        "mdot_kg_s": 0.1,
+        "eta_isothermal": 0.6,
+        "eta_isentropic": 0.7,
+    }
+    args.update(kwargs)
+
+    with pytest.raises(ValueError):
+        calculate_compressor(**args)


### PR DESCRIPTION
## Summary

Implements the next technical execution phase after PR-B.

This PR introduces the first modular tuple calculation implementation and the first executable fallback-engine tests.

The goal is to transition the framework from backend scaffolding toward deterministic engineering calculation execution.

## Scope

Adds:

- modular compressor tuple calculation
- fallback-engine executable tests
- deterministic calculation validation path

## Added Files

```text
src/gistau_ch15/calculations/compressor.py
tests/gistau_ch15/test_fallback_engine.py
```

## Technical Details

### Compressor tuple module

Implements:

```python
calculate_compressor(...)
```

Current implementation intentionally remains simplified while:

- preserving deterministic behavior
- enabling CI execution
- keeping REFPROP/HEPAK optional
- maintaining reproducibility

Outputs:

```python
CompressorResult
```

with:

- inlet/outlet pressures
- inlet/outlet temperatures
- shaft power
- efficiency

### Fallback backend tests

Adds executable tests for:

- PT state generation
- positive compressor power
- monotonic pressure increase
- monotonic outlet temperature increase

These become the initial engineering regression tests.

## Relation to Technical TODOs

This PR progresses:

- TODO-01 REFPROP integration readiness
- TODO-02 HEPAK integration readiness
- TODO-07 engineering-grade validation

by creating executable deterministic tuple outputs.

## Next Planned Work

Next modules:

- JT valve tuple
- heat exchanger tuple
- expander tuple
- equivalent power tuple

Next tests:

- idempotency checks
- backend contract checks
- tuple regression checks

Later:

- REFPROP backend
- HEPAK backend
- saturation dome overlays
- canonical validation reproduction

## Acceptance Criteria

- fallback backend remains self-contained
- tuple calculations execute deterministically
- tests run without external dependencies
- static HTML publication path unaffected
