### PR TITLE
PR-D: add JT valve and heat exchanger tuple modules

### DIFF
--- a/src/gistau_ch15/calculations/heat_exchanger.py
+++ b/src/gistau_ch15/calculations/heat_exchanger.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HeatExchangerResult:
+    hot_inlet_k: float
+    hot_outlet_k: float
+    cold_inlet_k: float
+    cold_outlet_k: float
+    effectiveness: float
+    q_transfer_w: float
+
+
+def calculate_heat_exchanger(
+    hot_inlet_k: float,
+    cold_inlet_k: float,
+    hot_capacity_rate_wk: float,
+    cold_capacity_rate_wk: float,
+    effectiveness: float,
+) -> HeatExchangerResult:
+    """Simplified epsilon-NTU style fallback heat exchanger.
+
+    This deterministic implementation is intentionally conservative until
+    canonical validation and REFPROP/HEPAK coupling are added.
+    """
+
+    if not 0.0 <= effectiveness <= 1.0:
+        raise ValueError("effectiveness must be between 0 and 1")
+
+    cmin = min(hot_capacity_rate_wk, cold_capacity_rate_wk)
+    qmax = cmin * max(hot_inlet_k - cold_inlet_k, 0.0)
+    q = effectiveness * qmax
+
+    hot_out = hot_inlet_k - q / max(hot_capacity_rate_wk, 1e-9)
+    cold_out = cold_inlet_k + q / max(cold_capacity_rate_wk, 1e-9)
+
+    return HeatExchangerResult(
+        hot_inlet_k=hot_inlet_k,
+        hot_outlet_k=hot_out,
+        cold_inlet_k=cold_inlet_k,
+        cold_outlet_k=cold_out,
+        effectiveness=effectiveness,
+        q_transfer_w=q,
+    )

--- a/src/gistau_ch15/calculations/jt_valve.py
+++ b/src/gistau_ch15/calculations/jt_valve.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from gistau_ch15.properties.base import PropertyBackend
+
+
+@dataclass(frozen=True)
+class JTValveResult:
+    inlet_pressure_kpa: float
+    outlet_pressure_kpa: float
+    inlet_temperature_k: float
+    outlet_temperature_k: float
+    inlet_enthalpy_j_kg: float
+    outlet_enthalpy_j_kg: float
+    energy_residual_j_kg: float
+
+
+def calculate_jt_valve(
+    backend: PropertyBackend,
+    fluid: str,
+    p1_kpa: float,
+    t1_k: float,
+    p2_kpa: float,
+    mdot_kg_s: float,
+    heat_leak_w: float = 0.0,
+) -> JTValveResult:
+    """Calculate a deterministic isenthalpic/free-expansion step.
+
+    Under fallback mode, outlet temperature is obtained through the backend's
+    PH inverse. Real REFPROP/HEPAK backends will later supply phase and quality.
+    """
+
+    if mdot_kg_s <= 0:
+        raise ValueError("mdot_kg_s must be positive")
+    if p2_kpa >= p1_kpa:
+        raise ValueError("JT/free expansion expects outlet pressure below inlet pressure")
+
+    inlet = backend.state_pt(fluid, p1_kpa, t1_k)
+    outlet_h = inlet.enthalpy_j_kg + heat_leak_w / mdot_kg_s
+    outlet = backend.state_ph(fluid, p2_kpa, outlet_h)
+    residual = outlet_h - inlet.enthalpy_j_kg - heat_leak_w / mdot_kg_s
+
+    return JTValveResult(
+        inlet_pressure_kpa=p1_kpa,
+        outlet_pressure_kpa=p2_kpa,
+        inlet_temperature_k=t1_k,
+        outlet_temperature_k=outlet.temperature_k,
+        inlet_enthalpy_j_kg=inlet.enthalpy_j_kg,
+        outlet_enthalpy_j_kg=outlet.enthalpy_j_kg,
+        energy_residual_j_kg=residual,
+    )

--- a/tests/gistau_ch15/test_idempotency.py
+++ b/tests/gistau_ch15/test_idempotency.py
@@ -1,0 +1,42 @@
+from gistau_ch15.calculations.heat_exchanger import calculate_heat_exchanger
+from gistau_ch15.calculations.jt_valve import calculate_jt_valve
+from gistau_ch15.properties.fallback_helium import FallbackHeliumBackend
+
+
+backend = FallbackHeliumBackend()
+
+
+def test_jt_valve_idempotent():
+    r1 = calculate_jt_valve(
+        backend=backend,
+        fluid='helium',
+        p1_kpa=1200.0,
+        t1_k=18.0,
+        p2_kpa=110.0,
+        mdot_kg_s=0.05,
+    )
+
+    r2 = calculate_jt_valve(
+        backend=backend,
+        fluid='helium',
+        p1_kpa=1200.0,
+        t1_k=18.0,
+        p2_kpa=110.0,
+        mdot_kg_s=0.05,
+    )
+
+    assert r1 == r2
+
+
+def test_heat_exchanger_bounds():
+    hx = calculate_heat_exchanger(
+        hot_inlet_k=300.0,
+        cold_inlet_k=80.0,
+        hot_capacity_rate_wk=500.0,
+        cold_capacity_rate_wk=350.0,
+        effectiveness=0.82,
+    )
+
+    assert hx.hot_outlet_k < hx.hot_inlet_k
+    assert hx.cold_outlet_k > hx.cold_inlet_k
+    assert hx.q_transfer_w > 0.0


### PR DESCRIPTION
## Summary

Implements the next deterministic engineering tuple layer after PR-C.

This PR adds:

- JT/free-expansion tuple calculation
- heat exchanger tuple calculation
- idempotency tests
- deterministic tuple validation logic

The framework now covers multiple major thermodynamic tuple categories.

## Added Files

```text
src/gistau_ch15/calculations/jt_valve.py
src/gistau_ch15/calculations/heat_exchanger.py
tests/gistau_ch15/test_idempotency.py
```

## Technical Details

### JT valve tuple

Implements:

```python
calculate_jt_valve(...)
```

Features:

- deterministic isenthalpic expansion
- PH inversion through backend
- energy residual reporting
- future phase/quality compatibility

Outputs:

```python
JTValveResult
```

### Heat exchanger tuple

Implements:

```python
calculate_heat_exchanger(...)
```

Features:

- epsilon-NTU style fallback logic
- deterministic thermal transfer
- bounded effectiveness
- reproducible outputs

Outputs:

```python
HeatExchangerResult
```

### Idempotency tests

Adds deterministic checks ensuring:

- repeated tuple execution produces identical outputs
- thermal bounds remain monotonic
- positive transfer behavior is preserved

These become foundational engineering regression tests.

## Relation to Technical TODOs

This PR progresses:

- TODO-01 REFPROP readiness
- TODO-02 HEPAK readiness
- TODO-04 phase-region reconstruction
- TODO-07 engineering-grade validation

by extending deterministic tuple execution across additional cryogenic domains.

## Next Planned Work

Next tuple modules:

- expander.py
- equivalent_power.py

Next validation:

- backend contract tests
- tuple regression baselines
- canonical example mapping

Later:

- saturation dome overlays
- true phase-region detection
- REFPROP backend
- HEPAK backend
- reproduction validation reports

## Acceptance Criteria

- deterministic tuple outputs preserved
- no external dependency introduced
- idempotency tests pass
- static publication path unaffected
