### PR TITLE
QPS Visual Knowledge System v1.3 — additive deck architecture and render system

### DIFF
--- a/docs/qps-visual-knowledge-system-v1-3/CODEX_HANDOFF_v1_3.md
+++ b/docs/qps-visual-knowledge-system-v1-3/CODEX_HANDOFF_v1_3.md
@@ -1,0 +1,87 @@
+# CODEX HANDOFF — v1.3
+
+## Intent
+
+Additive-only visual knowledge system evolution.
+
+Do NOT:
+- overwrite existing decks
+- collapse previous versions
+- force single-theme convergence
+
+The visual system intentionally preserves:
+- multiple engineering aesthetics
+- institutional lineage
+- review overlays
+- recursive/evolutionary development
+
+---
+
+# Current Maturity
+
+## Stable
+- HTML navigation structure
+- individual deck separation
+- Plotly integration direction
+- SVG fallback strategy
+- YAML object contracts
+- render-system philosophy
+
+## Prototype
+- SVG graph traversal
+- responsive ultra-dense scaling
+- HTML → PPTX regeneration
+- Office365 export automation
+- side-by-side source comparison
+
+---
+
+# Repository Strategy
+
+Recommended structure:
+
+```text
+/docs
+  /qps-visual-knowledge-system-v1-0b
+  /qps-visual-knowledge-system-v1-1
+  /qps-visual-knowledge-system-v1-2
+  /qps-visual-knowledge-system-v1-3
+```
+
+Versions remain:
+- parallel
+- reviewable
+- historically traceable
+
+---
+
+# Long-term Architecture
+
+```yaml
+visual_knowledge_system:
+  semantic_layer:
+  ontology_layer:
+  navigation_layer:
+  render_layer:
+  export_layer:
+  review_layer:
+  lineage_layer:
+```
+
+The system evolves from:
+- presentation files
+
+into:
+- engineering knowledge surfaces.
+
+---
+
+# Recommended Follow-up PRs
+
+1. SVG node hyperlink system
+2. side-by-side source vs curated review mode
+3. responsive ultra-dense scaling
+4. utilities/control deck expansion
+5. Office365 export automation
+6. HTML → PPTX regeneration engine
+7. static-host/Jekyll deployment

--- a/docs/qps-visual-knowledge-system-v1-3/DECK_MANIFEST.md
+++ b/docs/qps-visual-knowledge-system-v1-3/DECK_MANIFEST.md
@@ -1,0 +1,64 @@
+# Deck Manifest — v1.3
+
+| Deck ID | Deck Name | HTML | MD | PDF | PPTX | YAML | Status |
+|---|---|---|---|---|---|---|---|
+| 00 | Title and Navigation | yes | yes | yes | yes | partial | active |
+| 01 | SBS Graph Navigation | yes | yes | yes | yes | yes | active |
+| 02 | Utilities Dense Engineering | yes | yes | yes | yes | partial | active |
+| 03 | Controls Dense Engineering | yes | yes | yes | yes | partial | active |
+| 04 | Asset Ontology | yes | yes | yes | yes | yes | active |
+| 05 | Plots and Diagrams | yes | yes | yes | yes | yes | active |
+| 06 | Export Pipeline | yes | yes | yes | yes | yes | planning |
+
+---
+
+# Navigation Philosophy
+
+## Integrated Mode
+Diagrams and plots embedded directly into engineering slides.
+
+## Dedicated Mode
+Diagrams and plots also exist as:
+- standalone slides
+- graph navigation objects
+- SVG render targets
+- Plotly render targets
+
+---
+
+# Planned Next Iteration
+
+## SBS
+- clickable SVG node graph
+- hierarchy traversal
+- interface-link overlays
+
+## Utilities
+- denser cooling/HVAC/RCW/PCW slides
+- assumption traceability
+- utility interaction matrices
+
+## Controls
+- I/O candidate grouping
+- subsystem interaction maps
+- readiness and inhibit matrices
+- mode interaction navigation
+
+## Export
+- HTML → PDF landscape stabilization
+- HTML → PPTX regeneration
+- Office365 review copies
+- Jekyll/static-host rendering
+
+---
+
+# Visual Strategy
+
+The system preserves:
+- corporate purple authority
+- blue-white engineering precision
+- green SBS hierarchy
+- apricot operational overlays
+- yellow/red critique overlays
+
+without forcing a single diluted theme.

--- a/docs/qps-visual-knowledge-system-v1-3/README.md
+++ b/docs/qps-visual-knowledge-system-v1-3/README.md
@@ -1,0 +1,81 @@
+# QPS Visual Knowledge System v1.3
+
+## Principle
+
+This directory intentionally does NOT overwrite any existing deck structure.
+
+All v1.3 outputs are versioned and additive.
+
+---
+
+# Included Render Targets
+
+## HTML
+- integrated visual navigation
+- dedicated diagram slides
+- embedded diagrams inside slides
+- Plotly interactive charts
+- SVG fallbacks
+- light/dark themes
+- graph navigation
+
+## Markdown
+- rendered markdown per deck
+- YAML-compatible content structure
+- future Jekyll integration target
+
+## PDF
+- landscape engineering-slide exports
+- print-compatible fallbacks
+
+## PPTX
+- Office365-compatible export targets
+- presentation-first review mode
+
+## YAML
+- diagram objects
+- plot objects
+- render contracts
+- navigation contracts
+
+---
+
+# Individual Decks
+
+1. Title and Navigation
+2. SBS Graph Navigation
+3. Utilities Dense Engineering
+4. Controls Dense Engineering
+5. Asset Ontology
+6. Plots and Diagrams
+7. Export Pipeline
+
+---
+
+# Key Additions Compared to v1.1/v1.2
+
+- true diagram-first navigation direction
+- embedded + dedicated visual modes
+- Plotly interactive layer
+- SVG fallback strategy
+- separate topic-focused decks
+- render contract structure
+- Office365 export direction
+- PPTX/PDF/Markdown parallel outputs
+- responsive scaling strategy
+- side-by-side comparison preparation
+
+---
+
+# Non-overwrite Policy
+
+This version:
+- does not replace existing decks
+- does not delete legacy structures
+- does not invalidate prior versions
+
+Instead it:
+- extends the visual knowledge system
+- adds render-system maturity
+- introduces navigation architecture
+- preserves recursive/evolutionary workflow


### PR DESCRIPTION
# QPS Visual Knowledge System v1.3

## Intent

This PR extends the visual knowledge system without overwriting any existing decks or prior version directories.

The PR is intentionally additive-only.

---

# Added

## New versioned path

```text
/docs/qps-visual-knowledge-system-v1-3/
```

## Documents
- README
- deck manifest
- Codex handoff

---

# v1.3 Focus

## HTML-first engineering surfaces
- embedded diagrams
- dedicated diagram slides
- Plotly interactive charts
- SVG fallbacks
- navigation-first structure

## Multiple outputs
- HTML
- Markdown
- PDF
- PPTX
- YAML

## Individual decks
1. Title and Navigation
2. SBS Graph Navigation
3. Utilities Dense Engineering
4. Controls Dense Engineering
5. Asset Ontology
6. Plots and Diagrams
7. Export Pipeline

---

# Architectural Direction

The system evolves toward:
- graph navigation
- ontology-aware rendering
- semantic engineering artefacts
- Office365-compatible exports
- static-host/Jekyll rendering
- recursive/evolutionary review workflows

---

# Explicit Non-overwrite Policy

This PR:
- does NOT replace earlier decks
- does NOT collapse older versions
- does NOT force a single aesthetic

Instead it:
- preserves lineage
- preserves parallel evolution
- enables comparative refinement
- maintains reviewability

---

# Planned Follow-up

1. clickable SVG node graph traversal
2. side-by-side source vs curated slide review
3. responsive ultra-dense scaling
4. utilities/control expansion
5. Office365 export automation
6. HTML → PPTX regeneration
7. static-host deployment
