### PR TITLE
docs: add semantic framing and roadmap to QPS v1.3 README

### DIFF
--- a/docs/qps-visual-knowledge-system-v1-3/README.md
+++ b/docs/qps-visual-knowledge-system-v1-3/README.md
@@ -79,3 +79,52 @@ Instead it:
 - adds render-system maturity
 - introduces navigation architecture
 - preserves recursive/evolutionary workflow
+
+
+---
+
+# System Framing (Semantic Engineering)
+
+Slides are treated as **semantic engineering artefacts**, not presentation pages.
+
+Canonical architecture:
+
+```
+PPTX / PDF / Images
+  -> semantic extraction
+  -> YAML object layer
+  -> HTML engineering surface
+  -> multi-render export system
+```
+
+Core principles:
+- HTML-first
+- additive-only versioning
+- preserve lineage
+- preserve visual nuance
+- preserve engineering density
+- multiple style families are intentional
+- PPTX is an export target
+
+## Version Lineage
+
+Current versions tracked in this stream:
+- v1.0b
+- v1.1
+- v1.2
+- v1.3
+
+## Merged PRs
+
+- #56
+- #59
+
+## Next Priorities
+
+1. SVG graph traversal
+2. side-by-side review mode
+3. utilities/control expansion
+4. responsive ultra-dense rendering
+5. Office365 export automation
+6. HTML -> PPTX regeneration
+7. static-host deployment


### PR DESCRIPTION
### Motivation
- Clarify that slides are treated as semantic engineering artefacts and to make the canonical extraction->YAML->HTML->multi-render pipeline explicit. 
- Record core principles and version lineage for the v1.3 stream to support additive-only outputs and preserve provenance. 
- Capture merged PR references and an ordered set of next-priority engineering tasks to guide subsequent work.

### Description
- Appended a new `System Framing (Semantic Engineering)` section to `docs/qps-visual-knowledge-system-v1-3/README.md` that states the canonical architecture flow from `PPTX / PDF / Images` through `semantic extraction`, `YAML object layer`, `HTML engineering surface`, to `multi-render export system`.
- Added core principles (including `HTML-first`, `additive-only versioning`, `preserve lineage`, `preserve visual nuance`, `preserve engineering density`, and `PPTX` as an export target) to the README.
- Recorded current version lineage (`v1.0b`, `v1.1`, `v1.2`, `v1.3`), listed merged PRs (`#56`, `#59`), and added a seven-item next-priorities roadmap (SVG traversal, review mode, utilities/control expansion, ultra-dense rendering, Office365 automation, HTML->PPTX regeneration, static-host deployment).
- Change is purely additive documentation and does not modify existing structures or overwrite prior content.

### Testing
- Verified the diff with `git diff -- docs/qps-visual-knowledge-system-v1-3/README.md` and reviewed the inserted section. (succeeded)
- Inspected the updated file region with `nl -ba docs/qps-visual-knowledge-system-v1-3/README.md | sed -n '75,170p'` to confirm content placement. (succeeded)
- Committed the change with `git commit -m "docs: add semantic framing and roadmap to QPS v1.3 README"` and recorded PR metadata via the `make_pr` helper. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0aae20da34832e834be0fa6e16da17)