### PR TITLE
feat: operational recursive semantic runtime layer

### DIFF
--- a/semantic_substrate/runtime/orchestration_loop.py
+++ b/semantic_substrate/runtime/orchestration_loop.py
@@ -3,45 +3,108 @@ from __future__ import annotations
 import pathlib
 import subprocess
 import sys
+from typing import Iterable
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
-from typing import Iterable
 
+# Repo-local import must happen after the sys.path bootstrap above so this
+# module remains directly executable from the repository checkout.
 from semantic_substrate.engines.delta_extractor import generate_delta_stub
 
 VALIDATOR = ROOT / 'semantic_substrate' / 'validators' / 'validate_semantic_substrate.py'
 
 
+def _decode_git_bytes(value: bytes) -> str:
+    return value.decode('utf-8', errors='replace')
+
+
+def _parse_porcelain_z(output: bytes) -> list[str]:
+    """Parse `git status --porcelain=v1 -z` output into changed paths.
+
+    Rename and copy records are encoded as two NUL-delimited paths after the
+    two-character status and separating space. For semantic delta purposes the
+    destination path is the actual current changed file.
+    """
+    parts = [part for part in output.split(b'\0') if part]
+    files: list[str] = []
+    index = 0
+
+    while index < len(parts):
+        entry = parts[index]
+        status = entry[:2].decode('ascii', errors='replace')
+        path = entry[3:]
+
+        if status.startswith(('R', 'C')):
+            index += 1
+            if index < len(parts):
+                files.append(_decode_git_bytes(parts[index]))
+            else:
+                files.append(_decode_git_bytes(path))
+        else:
+            files.append(_decode_git_bytes(path))
+
+        index += 1
+
+    return files
+
+
 def _changed_files() -> list[str]:
-    """Return tracked files changed in git working tree."""
+    """Return tracked files changed in the git working tree."""
+    try:
+        result = subprocess.run(
+            ['git', 'status', '--porcelain=v1', '-z'],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=False,
+        )
+    except OSError as exc:
+        raise RuntimeError(f'Unable to run git status: {exc}') from exc
+
+    if result.returncode != 0:
+        stderr = result.stderr.decode('utf-8', errors='replace').strip()
+        raise RuntimeError(f'git status failed with exit code {result.returncode}: {stderr}')
+
+    return _parse_porcelain_z(result.stdout)
+
+
+def _run_validator() -> dict:
     result = subprocess.run(
-        ['git', 'status', '--porcelain'],
+        [sys.executable, str(VALIDATOR)],
         cwd=ROOT,
         check=False,
         capture_output=True,
         text=True,
     )
-    files: list[str] = []
-    for line in result.stdout.splitlines():
-        if not line:
-            continue
-        files.append(line[3:])
-    return files
-
-
-def _run_validator() -> int:
-    return subprocess.run([sys.executable, str(VALIDATOR)], cwd=ROOT, check=False).returncode
+    return {
+        'exit_code': result.returncode,
+        'stdout': result.stdout,
+        'stderr': result.stderr,
+    }
 
 
 def run_orchestration(changed_files: Iterable[str] | None = None) -> dict:
-    files = list(changed_files) if changed_files is not None else _changed_files()
-    delta = generate_delta_stub(files)
+    try:
+        files = list(changed_files) if changed_files is not None else _changed_files()
+        delta = generate_delta_stub(files)
+    except RuntimeError as exc:
+        return {
+            'validator_exit_code': None,
+            'validator_stdout': '',
+            'validator_stderr': '',
+            'delta': None,
+            'status': 'failed',
+            'error': str(exc),
+        }
 
-    validation_code = _run_validator()
+    validation = _run_validator()
+    validation_code = validation['exit_code']
     return {
         'validator_exit_code': validation_code,
+        'validator_stdout': validation['stdout'],
+        'validator_stderr': validation['stderr'],
         'delta': delta,
         'status': 'ok' if validation_code == 0 else 'failed',
     }

--- a/semantic_substrate/runtime/orchestration_loop.py
+++ b/semantic_substrate/runtime/orchestration_loop.py
@@ -37,11 +37,11 @@ def _parse_porcelain_z(output: bytes) -> list[str]:
         path = entry[3:]
 
         if status.startswith(('R', 'C')):
-            index += 1
-            if index < len(parts):
-                files.append(_decode_git_bytes(parts[index]))
-            else:
-                files.append(_decode_git_bytes(path))
+            # In --porcelain=v1 -z output, rename/copy records encode the
+            # destination path in the current entry and the origin path in the
+            # next NUL-delimited field.  We want the destination (current file).
+            files.append(_decode_git_bytes(path))
+            index += 1  # skip the origin path that follows
         else:
             files.append(_decode_git_bytes(path))
 
@@ -99,7 +99,18 @@ def run_orchestration(changed_files: Iterable[str] | None = None) -> dict:
             'error': str(exc),
         }
 
-    validation = _run_validator()
+    try:
+        validation = _run_validator()
+    except OSError as exc:
+        return {
+            'validator_exit_code': None,
+            'validator_stdout': '',
+            'validator_stderr': '',
+            'delta': delta,
+            'status': 'failed',
+            'error': str(exc),
+        }
+
     validation_code = validation['exit_code']
     return {
         'validator_exit_code': validation_code,
@@ -107,6 +118,7 @@ def run_orchestration(changed_files: Iterable[str] | None = None) -> dict:
         'validator_stderr': validation['stderr'],
         'delta': delta,
         'status': 'ok' if validation_code == 0 else 'failed',
+        'error': None,
     }
 
 

--- a/semantic_substrate/runtime/orchestration_loop.py
+++ b/semantic_substrate/runtime/orchestration_loop.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+from typing import Iterable
+
+from semantic_substrate.engines.delta_extractor import generate_delta_stub
+
+VALIDATOR = ROOT / 'semantic_substrate' / 'validators' / 'validate_semantic_substrate.py'
+
+
+def _changed_files() -> list[str]:
+    """Return tracked files changed in git working tree."""
+    result = subprocess.run(
+        ['git', 'status', '--porcelain'],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    files: list[str] = []
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        files.append(line[3:])
+    return files
+
+
+def _run_validator() -> int:
+    return subprocess.run([sys.executable, str(VALIDATOR)], cwd=ROOT, check=False).returncode
+
+
+def run_orchestration(changed_files: Iterable[str] | None = None) -> dict:
+    files = list(changed_files) if changed_files is not None else _changed_files()
+    delta = generate_delta_stub(files)
+
+    validation_code = _run_validator()
+    return {
+        'validator_exit_code': validation_code,
+        'delta': delta,
+        'status': 'ok' if validation_code == 0 else 'failed',
+    }
+
+
+if __name__ == '__main__':
+    print(run_orchestration())

--- a/tests/semantic_substrate/test_orchestration_loop.py
+++ b/tests/semantic_substrate/test_orchestration_loop.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from semantic_substrate.runtime.orchestration_loop import (
     _parse_porcelain_z,
     run_orchestration,
@@ -5,7 +7,9 @@ from semantic_substrate.runtime.orchestration_loop import (
 
 
 def test_parse_porcelain_handles_rename_records():
-    payload = b'R  old_name.txt\x00new_name.txt\x00'
+    # Real git --porcelain=v1 -z output: destination path is first in the entry,
+    # origin (old) path follows as the next NUL-delimited field.
+    payload = b'R  new_name.txt\x00old_name.txt\x00'
     assert _parse_porcelain_z(payload) == ['new_name.txt']
 
 
@@ -16,10 +20,48 @@ def test_parse_porcelain_handles_normal_records():
     ]
 
 
-def test_run_orchestration_payload_shape():
-    result = run_orchestration(changed_files=['README.md'])
+def test_run_orchestration_payload_shape_ok():
+    fake_validator = {
+        'exit_code': 0,
+        'stdout': 'SEMANTIC VALIDATION PASSED\n',
+        'stderr': '',
+    }
+    with patch(
+        'semantic_substrate.runtime.orchestration_loop._run_validator',
+        return_value=fake_validator,
+    ):
+        result = run_orchestration(changed_files=['README.md'])
 
-    assert 'validator_exit_code' in result
-    assert 'delta' in result
-    assert 'status' in result
-    assert result['status'] in {'ok', 'failed'}
+    assert result['validator_exit_code'] == 0
+    assert result['delta'] is not None
+    assert result['status'] == 'ok'
+    assert result['error'] is None
+    assert 'validator_stdout' in result
+    assert 'validator_stderr' in result
+
+
+def test_run_orchestration_payload_shape_failed():
+    fake_validator = {'exit_code': 1, 'stdout': '', 'stderr': 'validation error'}
+    with patch(
+        'semantic_substrate.runtime.orchestration_loop._run_validator',
+        return_value=fake_validator,
+    ):
+        result = run_orchestration(changed_files=['README.md'])
+
+    assert result['validator_exit_code'] == 1
+    assert result['status'] == 'failed'
+    assert result['error'] is None
+    assert 'validator_stdout' in result
+    assert 'validator_stderr' in result
+
+
+def test_run_orchestration_payload_shape_oserror():
+    with patch(
+        'semantic_substrate.runtime.orchestration_loop._run_validator',
+        side_effect=OSError('no python binary'),
+    ):
+        result = run_orchestration(changed_files=['README.md'])
+
+    assert result['status'] == 'failed'
+    assert result['validator_exit_code'] is None
+    assert 'no python binary' in result['error']

--- a/tests/semantic_substrate/test_orchestration_loop.py
+++ b/tests/semantic_substrate/test_orchestration_loop.py
@@ -1,0 +1,25 @@
+from semantic_substrate.runtime.orchestration_loop import (
+    _parse_porcelain_z,
+    run_orchestration,
+)
+
+
+def test_parse_porcelain_handles_rename_records():
+    payload = b'R  old_name.txt\x00new_name.txt\x00'
+    assert _parse_porcelain_z(payload) == ['new_name.txt']
+
+
+def test_parse_porcelain_handles_normal_records():
+    payload = b'M  semantic_substrate/runtime/orchestration_loop.py\x00'
+    assert _parse_porcelain_z(payload) == [
+        'semantic_substrate/runtime/orchestration_loop.py'
+    ]
+
+
+def test_run_orchestration_payload_shape():
+    result = run_orchestration(changed_files=['README.md'])
+
+    assert 'validator_exit_code' in result
+    assert 'delta' in result
+    assert 'status' in result
+    assert result['status'] in {'ok', 'failed'}


### PR DESCRIPTION
### Motivation
- Provide an executable orchestration entrypoint to operationalize the semantic substrate and bridge repository metadata into a runtime substrate. 
- Enable automated delta extraction and validator-driven runtime checks as a foundation for replay, observability, and multi-agent coordination.

### Description
- Add `semantic_substrate/runtime/orchestration_loop.py` which implements `run_orchestration`, bootstraps repository imports for direct execution, collects changed files via `git status`, and generates a semantic delta using `generate_delta_stub`.
- Integrate runtime execution of the semantic validator located at `semantic_substrate/validators/validate_semantic_substrate.py` and surface a structured status payload with `validator_exit_code`, `delta`, and `status`.
- Wire into the existing delta extraction engine at `semantic_substrate/engines/delta_extractor.py` and include a small `sys.path` adjustment to allow running the script from the repository context.

### Testing
- Ran `python semantic_substrate/runtime/orchestration_loop.py` which executed and returned a status payload with `validator_exit_code` 0 indicating success.
- Ran `python semantic_substrate/validators/validate_semantic_substrate.py` which printed `SEMANTIC VALIDATION PASSED`.
- Ran `python semantic_substrate/viewers/semantic_graph_renderer.py` which failed in the environment due to a missing dependency (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b65428ecc832ea897482c41aae7c3)