### PR TITLE
Add overlay artifact manifest builder and refresh flow with test and seed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ GISTAU/derived/tmp/
 # Generated handoff bundles (binary)
 handoff/*_handover_bundle.zip
 handoff/*_handover_bundle.tar.gz
+outputs/

--- a/docs/gistau-ch15/data/generated_overlay_manifest.json
+++ b/docs/gistau-ch15/data/generated_overlay_manifest.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0",
+  "artifact_count": 2,
+  "artifacts": [
+    {
+      "key": "plotly_trace_export",
+      "path": "docs/gistau-ch15/data/plotly_trace_export.json",
+      "sha256": "a500a6f4f051bfc47d552a7b92fddf53c6ebca21610418fac50ab23d72ba4503",
+      "size_bytes": 1182
+    },
+    {
+      "key": "thermo_visual_overlay_seed",
+      "path": "docs/gistau-ch15/data/thermo_visual_overlay_seed.json",
+      "sha256": "dde0da1b4f5096811b456414443dcb7d07a89745d6533fa9d38d17d89b1c2a0d",
+      "size_bytes": 2449
+    }
+  ]
+}

--- a/docs/gistau-ch15/data/plotly_trace_export.json
+++ b/docs/gistau-ch15/data/plotly_trace_export.json
@@ -1,0 +1,88 @@
+{
+  "saturation": [
+    {
+      "type": "scatter",
+      "mode": "lines+markers",
+      "name": "liquid branch",
+      "x": [
+        5,
+        12,
+        20,
+        31,
+        45,
+        62
+      ],
+      "y": [
+        1.8,
+        2.0,
+        2.4,
+        3.0,
+        3.8,
+        4.6
+      ]
+    },
+    {
+      "type": "scatter",
+      "mode": "lines+markers",
+      "name": "vapor branch",
+      "x": [
+        450,
+        390,
+        330,
+        270,
+        220,
+        180
+      ],
+      "y": [
+        1.8,
+        2.0,
+        2.4,
+        3.0,
+        3.8,
+        4.6
+      ]
+    }
+  ],
+  "agreement": {
+    "type": "heatmap",
+    "name": "backend agreement",
+    "x": [
+      "fallback",
+      "coolprop",
+      "refprop",
+      "hepak"
+    ],
+    "y": [
+      "T00 property",
+      "T02 saturation",
+      "T04 expander",
+      "T05 compressor"
+    ],
+    "z": [
+      [
+        0.62,
+        0.88,
+        1.0,
+        0.95
+      ],
+      [
+        0.3,
+        0.72,
+        0.86,
+        1.0
+      ],
+      [
+        0.45,
+        0.78,
+        0.91,
+        0.96
+      ],
+      [
+        0.28,
+        0.7,
+        0.89,
+        1.0
+      ]
+    ]
+  }
+}

--- a/docs/gistau-ch15/data/thermo_visual_overlay_seed.json
+++ b/docs/gistau-ch15/data/thermo_visual_overlay_seed.json
@@ -1,50 +1,194 @@
 {
   "metadata": {
-    "phase": "PR-H",
-    "status": "deterministic placeholder data"
+    "generator": "regenerate_overlay_json",
+    "mode": "deterministic_fallback"
   },
   "saturation_dome": {
-    "entropy_liquid": [5, 12, 20, 31, 45, 62, 82, 105],
-    "temperature_liquid": [1.8, 2.0, 2.4, 3.0, 3.8, 4.6, 5.2, 5.8],
-    "entropy_vapor": [450, 390, 330, 270, 220, 180, 145, 115],
-    "temperature_vapor": [1.8, 2.0, 2.4, 3.0, 3.8, 4.6, 5.2, 5.8]
+    "entropy_liquid": [
+      5,
+      12,
+      20,
+      31,
+      45,
+      62
+    ],
+    "temperature_liquid": [
+      1.8,
+      2.0,
+      2.4,
+      3.0,
+      3.8,
+      4.6
+    ],
+    "entropy_vapor": [
+      450,
+      390,
+      330,
+      270,
+      220,
+      180
+    ],
+    "temperature_vapor": [
+      1.8,
+      2.0,
+      2.4,
+      3.0,
+      3.8,
+      4.6
+    ]
   },
   "ts_paths": [
     {
       "name": "expander path",
-      "entropy": [90, 108, 132, 160, 190],
-      "temperature": [80, 58, 36, 18, 5]
+      "entropy": [
+        90,
+        108,
+        132,
+        160,
+        190
+      ],
+      "temperature": [
+        80,
+        58,
+        36,
+        18,
+        5
+      ]
     },
     {
       "name": "low temperature path",
-      "entropy": [45, 60, 82, 115, 165],
-      "temperature": [12, 8, 5, 3, 2]
+      "entropy": [
+        45,
+        60,
+        82,
+        115,
+        165
+      ],
+      "temperature": [
+        12,
+        8,
+        5,
+        3,
+        2
+      ]
     }
   ],
   "phase_map": {
-    "pressure": [5, 10, 20, 50, 100, 200, 500, 1000],
-    "temperature": [1.8, 2.0, 2.5, 3.0, 4.2, 5.0, 8.0, 12.0],
-    "code": [1, 1, 2, 2, 2, 3, 3, 3]
-  },
-  "backend_delta": {
-    "backend": ["fallback", "coolprop", "refprop", "hepak"],
-    "enthalpy_pct": [12.5, 2.1, 0.0, 0.4],
-    "density_pct": [18.0, 3.2, 0.0, 0.6],
-    "temperature_k": [1.2, 0.25, 0.0, 0.05]
+    "pressure": [
+      5,
+      10,
+      20,
+      50,
+      100,
+      200,
+      500,
+      1000
+    ],
+    "temperature": [
+      1.8,
+      2.0,
+      2.5,
+      3.0,
+      4.2,
+      5.0,
+      8.0,
+      12.0
+    ],
+    "code": [
+      1,
+      1,
+      2,
+      2,
+      2,
+      3,
+      3,
+      3
+    ]
   },
   "expander": {
-    "station": ["inlet", "ideal outlet", "actual outlet", "check point"],
-    "temperature": [80, 22, 32, 32],
-    "pressure": [1200, 110, 110, 110]
+    "station": [
+      "inlet",
+      "ideal outlet",
+      "actual outlet",
+      "check point"
+    ],
+    "temperature": [
+      80.0,
+      22.0,
+      32.0,
+      32.0
+    ],
+    "pressure": [
+      1200.0,
+      110.0,
+      110.0,
+      110.0
+    ]
   },
   "agreement": {
-    "x": ["fallback", "coolprop", "refprop", "hepak"],
-    "y": ["T00 property", "T02 saturation", "T04 expander", "T05 compressor"],
+    "x": [
+      "fallback",
+      "coolprop",
+      "refprop",
+      "hepak"
+    ],
+    "y": [
+      "T00 property",
+      "T02 saturation",
+      "T04 expander",
+      "T05 compressor"
+    ],
     "z": [
-      [0.62, 0.88, 1.00, 0.95],
-      [0.30, 0.72, 0.86, 1.00],
-      [0.45, 0.78, 0.91, 0.96],
-      [0.28, 0.70, 0.89, 1.00]
+      [
+        0.62,
+        0.88,
+        1.0,
+        0.95
+      ],
+      [
+        0.3,
+        0.72,
+        0.86,
+        1.0
+      ],
+      [
+        0.45,
+        0.78,
+        0.91,
+        0.96
+      ],
+      [
+        0.28,
+        0.7,
+        0.89,
+        1.0
+      ]
+    ]
+  },
+  "backend_delta": {
+    "backend": [
+      "fallback",
+      "coolprop",
+      "refprop",
+      "hepak"
+    ],
+    "enthalpy_pct": [
+      12.5,
+      2.1,
+      0.0,
+      0.4
+    ],
+    "density_pct": [
+      18.0,
+      3.2,
+      0.0,
+      0.6
+    ],
+    "temperature_k": [
+      1.2,
+      0.25,
+      0.0,
+      0.05
     ]
   }
 }

--- a/src/gistau_ch15/visualization/overlay_artifact_manifest.py
+++ b/src/gistau_ch15/visualization/overlay_artifact_manifest.py
@@ -47,8 +47,10 @@ class OverlayArtifactManifestBuilder:
         self,
         artifacts: list[Path],
         output_path: str | Path,
+        *,
+        root: Path | None = None,
     ) -> Path:
-        records = self.build_records(artifacts)
+        records = self.build_records(artifacts, root=root)
 
         payload = {
             "schema_version": "1.0",

--- a/src/gistau_ch15/visualization/overlay_artifact_manifest.py
+++ b/src/gistau_ch15/visualization/overlay_artifact_manifest.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class OverlayArtifactRecord:
+    """Manifest entry for one generated overlay artifact."""
+
+    key: str
+    path: str
+    sha256: str
+    size_bytes: int
+
+
+class OverlayArtifactManifestBuilder:
+    """Build and persist manifest metadata for generated overlay artifacts."""
+
+    def build_records(
+        self,
+        artifacts: list[Path],
+        *,
+        root: Path | None = None,
+    ) -> list[OverlayArtifactRecord]:
+        base = root or Path.cwd()
+        records: list[OverlayArtifactRecord] = []
+
+        for artifact in artifacts:
+            path = Path(artifact).resolve()
+            payload = path.read_bytes()
+            rel_path = path.relative_to(base.resolve()).as_posix()
+            records.append(
+                OverlayArtifactRecord(
+                    key=path.stem,
+                    path=rel_path,
+                    sha256=hashlib.sha256(payload).hexdigest(),
+                    size_bytes=len(payload),
+                )
+            )
+
+        return sorted(records, key=lambda r: r.path)
+
+    def write_manifest(
+        self,
+        artifacts: list[Path],
+        output_path: str | Path,
+    ) -> Path:
+        records = self.build_records(artifacts)
+
+        payload = {
+            "schema_version": "1.0",
+            "artifact_count": len(records),
+            "artifacts": [record.__dict__ for record in records],
+        }
+
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        return path

--- a/src/gistau_ch15/visualization/overlay_artifact_manifest.py
+++ b/src/gistau_ch15/visualization/overlay_artifact_manifest.py
@@ -25,17 +25,20 @@ class OverlayArtifactManifestBuilder:
         *,
         root: Path | None = None,
     ) -> list[OverlayArtifactRecord]:
-        base = root or Path.cwd()
+        base = (root or Path.cwd()).resolve()
         records: list[OverlayArtifactRecord] = []
 
         for artifact in artifacts:
             path = Path(artifact).resolve()
             payload = path.read_bytes()
-            rel_path = path.relative_to(base.resolve()).as_posix()
+            try:
+                record_path = path.relative_to(base).as_posix()
+            except ValueError:
+                record_path = path.as_posix()
             records.append(
                 OverlayArtifactRecord(
                     key=path.stem,
-                    path=rel_path,
+                    path=record_path,
                     sha256=hashlib.sha256(payload).hexdigest(),
                     size_bytes=len(payload),
                 )

--- a/src/gistau_ch15/visualization/pages_artifact_refresh.py
+++ b/src/gistau_ch15/visualization/pages_artifact_refresh.py
@@ -11,10 +11,35 @@ from gistau_ch15.visualization.trace_json_export import (
 class PagesArtifactRefresh:
     """Refresh GitHub Pages-visible visualization artifacts."""
 
-    def refresh(self) -> list[Path]:
+    def refresh(
+        self,
+        *,
+        overlay_output: Path | None = None,
+        trace_output: Path | None = None,
+    ) -> list[Path]:
+        """Refresh artifacts, optionally redirecting outputs.
+        
+        Args:
+            overlay_output: Optional path for thermo_visual_overlay_seed.json
+            trace_output: Optional path for plotly_trace_export.json
+        """
         outputs: list[Path] = []
 
-        outputs.append(regenerate())
-        outputs.append(PlotlyTraceJSONExporter().export())
+        if overlay_output is not None:
+            # Temporarily redirect regenerate() output
+            from gistau_ch15.visualization import regenerate_overlay_json
+            original = regenerate_overlay_json.OUTPUT
+            regenerate_overlay_json.OUTPUT = overlay_output
+            try:
+                outputs.append(regenerate())
+            finally:
+                regenerate_overlay_json.OUTPUT = original
+        else:
+            outputs.append(regenerate())
+
+        if trace_output is not None:
+            outputs.append(PlotlyTraceJSONExporter().export(trace_output))
+        else:
+            outputs.append(PlotlyTraceJSONExporter().export())
 
         return outputs

--- a/src/gistau_ch15/visualization/pages_artifact_refresh.py
+++ b/src/gistau_ch15/visualization/pages_artifact_refresh.py
@@ -18,7 +18,7 @@ class PagesArtifactRefresh:
         trace_output: Path | None = None,
     ) -> list[Path]:
         """Refresh artifacts, optionally redirecting outputs.
-        
+
         Args:
             overlay_output: Optional path for thermo_visual_overlay_seed.json
             trace_output: Optional path for plotly_trace_export.json
@@ -26,14 +26,7 @@ class PagesArtifactRefresh:
         outputs: list[Path] = []
 
         if overlay_output is not None:
-            # Temporarily redirect regenerate() output
-            from gistau_ch15.visualization import regenerate_overlay_json
-            original = regenerate_overlay_json.OUTPUT
-            regenerate_overlay_json.OUTPUT = overlay_output
-            try:
-                outputs.append(regenerate())
-            finally:
-                regenerate_overlay_json.OUTPUT = original
+            outputs.append(regenerate(overlay_output))
         else:
             outputs.append(regenerate())
 

--- a/src/gistau_ch15/visualization/refresh_overlay_artifacts.py
+++ b/src/gistau_ch15/visualization/refresh_overlay_artifacts.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from gistau_ch15.visualization import regenerate_overlay_json
+from gistau_ch15.visualization import trace_json_export
 from gistau_ch15.visualization.overlay_artifact_manifest import (
     OverlayArtifactManifestBuilder,
 )
@@ -10,6 +12,13 @@ from gistau_ch15.visualization.pages_artifact_refresh import (
 )
 
 MANIFEST_OUTPUT = Path("docs/gistau-ch15/data/generated_overlay_manifest.json")
+
+
+def _resolve_under_root(path: str | Path, root: Path) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return root / candidate
 
 
 def refresh_overlay_artifacts(
@@ -24,21 +33,35 @@ def refresh_overlay_artifacts(
     Args:
         manifest_output: Path where the manifest JSON will be written.
         root: Base directory for computing relative paths in the manifest.
-              Defaults to the repository root (parent of docs/).
+              Defaults to the repository root (parent of docs/) and is
+              also used as the base for default relative output paths.
         overlay_output: Optional path for thermo_visual_overlay_seed.json
         trace_output: Optional path for plotly_trace_export.json
     """
     if root is None:
         # Default to repo root (parent of docs/) for stable relative paths
         root = Path(__file__).resolve().parent.parent.parent.parent
+    root = root.resolve()
+
+    resolved_overlay_output = (
+        _resolve_under_root(overlay_output, root)
+        if overlay_output is not None
+        else _resolve_under_root(regenerate_overlay_json.OUTPUT, root)
+    )
+    resolved_trace_output = (
+        _resolve_under_root(trace_output, root)
+        if trace_output is not None
+        else _resolve_under_root(trace_json_export.OUTPUT, root)
+    )
+    resolved_manifest_output = _resolve_under_root(manifest_output, root)
 
     artifacts = PagesArtifactRefresh().refresh(
-        overlay_output=overlay_output,
-        trace_output=trace_output,
+        overlay_output=resolved_overlay_output,
+        trace_output=resolved_trace_output,
     )
     manifest = OverlayArtifactManifestBuilder().write_manifest(
         artifacts,
-        manifest_output,
+        resolved_manifest_output,
         root=root,
     )
     return [*artifacts, manifest]

--- a/src/gistau_ch15/visualization/refresh_overlay_artifacts.py
+++ b/src/gistau_ch15/visualization/refresh_overlay_artifacts.py
@@ -14,12 +14,31 @@ MANIFEST_OUTPUT = Path("docs/gistau-ch15/data/generated_overlay_manifest.json")
 
 def refresh_overlay_artifacts(
     manifest_output: str | Path = MANIFEST_OUTPUT,
+    *,
+    root: Path | None = None,
+    overlay_output: Path | None = None,
+    trace_output: Path | None = None,
 ) -> list[Path]:
-    """Refresh Pages artifacts and regenerate generated overlay manifest."""
+    """Refresh Pages artifacts and regenerate generated overlay manifest.
+    
+    Args:
+        manifest_output: Path where the manifest JSON will be written.
+        root: Base directory for computing relative paths in the manifest.
+              Defaults to the repository root (parent of docs/).
+        overlay_output: Optional path for thermo_visual_overlay_seed.json
+        trace_output: Optional path for plotly_trace_export.json
+    """
+    if root is None:
+        # Default to repo root (parent of docs/) for stable relative paths
+        root = Path(__file__).resolve().parent.parent.parent.parent
 
-    artifacts = PagesArtifactRefresh().refresh()
+    artifacts = PagesArtifactRefresh().refresh(
+        overlay_output=overlay_output,
+        trace_output=trace_output,
+    )
     manifest = OverlayArtifactManifestBuilder().write_manifest(
         artifacts,
         manifest_output,
+        root=root,
     )
     return [*artifacts, manifest]

--- a/src/gistau_ch15/visualization/refresh_overlay_artifacts.py
+++ b/src/gistau_ch15/visualization/refresh_overlay_artifacts.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gistau_ch15.visualization.overlay_artifact_manifest import (
+    OverlayArtifactManifestBuilder,
+)
+from gistau_ch15.visualization.pages_artifact_refresh import (
+    PagesArtifactRefresh,
+)
+
+MANIFEST_OUTPUT = Path("docs/gistau-ch15/data/generated_overlay_manifest.json")
+
+
+def refresh_overlay_artifacts(
+    manifest_output: str | Path = MANIFEST_OUTPUT,
+) -> list[Path]:
+    """Refresh Pages artifacts and regenerate generated overlay manifest."""
+
+    artifacts = PagesArtifactRefresh().refresh()
+    manifest = OverlayArtifactManifestBuilder().write_manifest(
+        artifacts,
+        manifest_output,
+    )
+    return [*artifacts, manifest]

--- a/src/gistau_ch15/visualization/regenerate_overlay_json.py
+++ b/src/gistau_ch15/visualization/regenerate_overlay_json.py
@@ -26,7 +26,12 @@ from gistau_ch15.visualization.ts_reconstruction import (
 OUTPUT = Path("docs/gistau-ch15/data/thermo_visual_overlay_seed.json")
 
 
-def regenerate() -> Path:
+def regenerate(output_path: str | Path = OUTPUT) -> Path:
+    """Regenerate overlay JSON with deterministic fallback data.
+    
+    Args:
+        output_path: Path where the overlay JSON will be written.
+    """
     saturation = FallbackSaturationSampler().sample()
     ts_paths = FallbackTSReconstructor().build_paths()
     phase_map = FallbackPhaseMapSampler().sample()
@@ -76,10 +81,11 @@ def regenerate() -> Path:
         },
     }
 
-    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
-    OUTPUT.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
-    return OUTPUT
+    return path
 
 
 if __name__ == "__main__":

--- a/tests/gistau_ch15/test_refresh_overlay_artifacts.py
+++ b/tests/gistau_ch15/test_refresh_overlay_artifacts.py
@@ -34,7 +34,7 @@ def test_refresh_overlay_artifacts_writes_manifest(tmp_path: Path):
     # Verify artifacts list structure
     assert "artifacts" in manifest
     assert len(manifest["artifacts"]) == expected_artifact_count
-    
+
     # Verify each artifact has required fields
     for artifact in manifest["artifacts"]:
         assert "key" in artifact

--- a/tests/gistau_ch15/test_refresh_overlay_artifacts.py
+++ b/tests/gistau_ch15/test_refresh_overlay_artifacts.py
@@ -26,11 +26,11 @@ def test_refresh_overlay_artifacts_writes_manifest(tmp_path: Path):
     # Parse and validate manifest structure
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["schema_version"] == "1.0"
-    
+
     # Derive expected count from actual artifacts (2 data files + 1 manifest)
     expected_artifact_count = len([p for p in outputs if p != manifest_path])
     assert manifest["artifact_count"] == expected_artifact_count
-    
+
     # Verify artifacts list structure
     assert "artifacts" in manifest
     assert len(manifest["artifacts"]) == expected_artifact_count

--- a/tests/gistau_ch15/test_refresh_overlay_artifacts.py
+++ b/tests/gistau_ch15/test_refresh_overlay_artifacts.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from gistau_ch15.visualization.refresh_overlay_artifacts import (
@@ -6,13 +7,37 @@ from gistau_ch15.visualization.refresh_overlay_artifacts import (
 
 
 def test_refresh_overlay_artifacts_writes_manifest(tmp_path: Path):
+    # Redirect all outputs to tmp_path
+    overlay_output = tmp_path / "thermo_visual_overlay_seed.json"
+    trace_output = tmp_path / "plotly_trace_export.json"
     manifest_path = tmp_path / "generated_overlay_manifest.json"
 
-    outputs = refresh_overlay_artifacts(manifest_path)
+    outputs = refresh_overlay_artifacts(
+        manifest_path,
+        root=tmp_path,
+        overlay_output=overlay_output,
+        trace_output=trace_output,
+    )
 
+    # Verify manifest is in outputs and exists
     assert manifest_path in outputs
     assert manifest_path.exists()
 
-    payload = manifest_path.read_text(encoding="utf-8")
-    assert '"schema_version": "1.0"' in payload
-    assert '"artifact_count": 2' in payload
+    # Parse and validate manifest structure
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "1.0"
+    
+    # Derive expected count from actual artifacts (2 data files + 1 manifest)
+    expected_artifact_count = len([p for p in outputs if p != manifest_path])
+    assert manifest["artifact_count"] == expected_artifact_count
+    
+    # Verify artifacts list structure
+    assert "artifacts" in manifest
+    assert len(manifest["artifacts"]) == expected_artifact_count
+    
+    # Verify each artifact has required fields
+    for artifact in manifest["artifacts"]:
+        assert "key" in artifact
+        assert "path" in artifact
+        assert "sha256" in artifact
+        assert "size_bytes" in artifact

--- a/tests/gistau_ch15/test_refresh_overlay_artifacts.py
+++ b/tests/gistau_ch15/test_refresh_overlay_artifacts.py
@@ -27,7 +27,7 @@ def test_refresh_overlay_artifacts_writes_manifest(tmp_path: Path):
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["schema_version"] == "1.0"
 
-    # Derive expected count from actual artifacts (2 data files + 1 manifest)
+    # Derive expected count from refreshed artifacts (manifest excluded)
     expected_artifact_count = len([p for p in outputs if p != manifest_path])
     assert manifest["artifact_count"] == expected_artifact_count
 
@@ -41,3 +41,20 @@ def test_refresh_overlay_artifacts_writes_manifest(tmp_path: Path):
         assert "path" in artifact
         assert "sha256" in artifact
         assert "size_bytes" in artifact
+
+
+def test_refresh_overlay_artifacts_default_paths_are_root_relative(tmp_path: Path):
+    outputs = refresh_overlay_artifacts(root=tmp_path)
+
+    overlay_output = tmp_path / "docs/gistau-ch15/data/thermo_visual_overlay_seed.json"
+    trace_output = tmp_path / "docs/gistau-ch15/data/plotly_trace_export.json"
+    manifest_path = tmp_path / "docs/gistau-ch15/data/generated_overlay_manifest.json"
+    assert outputs == [overlay_output, trace_output, manifest_path]
+    assert all(path.exists() for path in outputs)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["artifact_count"] == 2
+    assert {item["path"] for item in manifest["artifacts"]} == {
+        "docs/gistau-ch15/data/thermo_visual_overlay_seed.json",
+        "docs/gistau-ch15/data/plotly_trace_export.json",
+    }

--- a/tests/gistau_ch15/test_refresh_overlay_artifacts.py
+++ b/tests/gistau_ch15/test_refresh_overlay_artifacts.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from gistau_ch15.visualization.refresh_overlay_artifacts import (
+    refresh_overlay_artifacts,
+)
+
+
+def test_refresh_overlay_artifacts_writes_manifest(tmp_path: Path):
+    manifest_path = tmp_path / "generated_overlay_manifest.json"
+
+    outputs = refresh_overlay_artifacts(manifest_path)
+
+    assert manifest_path in outputs
+    assert manifest_path.exists()
+
+    payload = manifest_path.read_text(encoding="utf-8")
+    assert '"schema_version": "1.0"' in payload
+    assert '"artifact_count": 2' in payload

--- a/tests/gistau_ch15/test_visualization_scaffolds.py
+++ b/tests/gistau_ch15/test_visualization_scaffolds.py
@@ -41,12 +41,7 @@ def test_backend_agreement_builder_returns_matrix():
 
 def test_regenerate_overlay_json_matches_dashboard_schema(tmp_path):
     output = tmp_path / "seed.json"
-    original_output = regenerate_overlay_json.OUTPUT
-    regenerate_overlay_json.OUTPUT = output
-    try:
-        regenerate_overlay_json.regenerate()
-    finally:
-        regenerate_overlay_json.OUTPUT = original_output
+    regenerate_overlay_json.regenerate(output)
 
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert "saturation_dome" in payload


### PR DESCRIPTION
### Motivation

- Provide a reproducible manifest for generated visualization overlay artifacts so downstream tooling can verify contents by path, checksum and size.
- Expose a simple refresh entrypoint that updates Pages artifacts and regenerates the manifest for documentation artifacts.

### Description

- Add `OverlayArtifactManifestBuilder` which computes `sha256`, `size_bytes`, and relative `path` for provided artifact `Path`s and writes a manifest JSON with `schema_version`, `artifact_count`, and `artifacts` entries.
- Add `refresh_overlay_artifacts` entrypoint which calls `PagesArtifactRefresh().refresh()` and writes the manifest to `docs/gistau-ch15/data/generated_overlay_manifest.json` by default.
- Add test `tests/gistau_ch15/test_refresh_overlay_artifacts.py` to validate the manifest is produced and contains `schema_version` and expected `artifact_count` when invoked with a temporary output path.
- Add/update deterministic overlay seed/data files under `docs/gistau-ch15/data/` including `plotly_trace_export.json` and `thermo_visual_overlay_seed.json` to provide stable inputs for visualization artifacts.

### Testing

- Ran the new unit test with `pytest tests/gistau_ch15/test_refresh_overlay_artifacts.py`, which created a manifest in a `tmp_path` and asserted the manifest exists and contains `"schema_version": "1.0"` and `"artifact_count": 2`; the test passed.
- The manifest writer was exercised end-to-end by the same test, validating `artifacts` serialization and file writing succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b8469cbc8832ebd05533b694170b2)