### PR TITLE
Harden dark-mode warning card contrast in GISTAU visual cards

### DIFF
--- a/docs/gistau-ch15/visual_cards.css
+++ b/docs/gistau-ch15/visual_cards.css
@@ -1,1 +1,28 @@
 body{font-family:Arial,sans-serif;background:#fff;color:#000;margin:0}.topbar{padding:16px;border-bottom:4px solid #000}.layout{display:grid;grid-template-columns:repeat(auto-fit,minmax(360px,1fr));gap:16px;padding:16px}.card{border:3px solid #000;border-radius:12px;padding:16px;background:#fff}.active{border-color:#008000}.warning{border-color:#c00000}.neutral{border-color:#000}.entry-links{display:flex;gap:10px;flex-wrap:wrap}.entry-links a{border:2px solid #000;border-radius:999px;padding:8px 12px;text-decoration:none;color:#000;font-weight:800}.entry-links a.primary{border-color:#008000;color:#008000}.entry-links a.warning{border-color:#c00000;color:#c00000}table{width:100%;border-collapse:collapse;margin-top:12px}th,td{border:1px solid #000;padding:8px;vertical-align:top}th{background:#000;color:#fff}.green-text{color:#008000;font-weight:bold}.red-text{color:#c00000;font-weight:bold}.black-text{color:#000;font-weight:bold}.node{display:inline-block;border:2px solid #000;border-radius:999px;padding:8px 12px;font-weight:bold}.node.green{border-color:#008000;color:#008000}.node.red{border-color:#c00000;color:#c00000}.node.black{border-color:#000;color:#000}.arrow{padding:0 8px;font-weight:900}.svg-preview{width:100%;min-height:260px;border:2px solid #000;background:#f7f7f7}.source{border-left:6px solid #000;padding-left:10px;font-weight:700}.ok{background:#e6f4e6;color:#008000}.warn{background:#fff4e5;color:#c00000}.blocked{background:#ffeaea;color:#c00000}.ref{background:#f2f2f2;color:#000}
+
+@media (prefers-color-scheme: dark){
+  body{background:#181421;color:#f5f2ff}
+  .topbar{border-bottom-color:#e5d2ff}
+  .card{background:#241d33;border-color:#8f7abd;color:#f5f2ff}
+  .active{border-color:#5fd08d}
+  .neutral{border-color:#cfc2ef}
+  .warning{background:#3b2a00;border-color:#c89b00;color:#ffe9a3}
+  .entry-links a{border-color:#cfc2ef;color:#f5f2ff}
+  .entry-links a.primary{border-color:#5fd08d;color:#9cf2be}
+  .entry-links a.warning{border-color:#c89b00;color:#ffe9a3}
+  th,td{border-color:#cfc2ef}
+  th{background:#2f2347;color:#f5f2ff}
+  .green-text{color:#9cf2be}
+  .red-text{color:#ffe9a3}
+  .black-text{color:#f5f2ff}
+  .node{border-color:#cfc2ef;color:#f5f2ff}
+  .node.green{border-color:#5fd08d;color:#9cf2be}
+  .node.red{border-color:#c89b00;color:#ffe9a3}
+  .node.black{border-color:#cfc2ef;color:#f5f2ff}
+  .svg-preview{border-color:#cfc2ef;background:#20182e}
+  .source{border-left-color:#cfc2ef}
+  .ok{background:#1f3a2d;color:#b8f5cf}
+  .warn{background:#4a3110;color:#ffe9a3}
+  .blocked{background:#442033;color:#ffd6f0}
+  .ref{background:#2f2347;color:#efe8ff}
+}


### PR DESCRIPTION
### Motivation
- Dark-mode warning cards used a light/pastel yellow that produced low contrast with pale text, reducing readability and failing contrast accessibility goals.
- The renderer should apply semantic color transforms by theme rather than naive inversion so warning semantics stay legible and visually distinct in dark contexts.

### Description
- Added an `@media (prefers-color-scheme: dark)` block to `docs/gistau-ch15/visual_cards.css` to provide dark-theme overrides.
- Hardened the `.warning` styling to `background: #3b2a00`, `border-color: #c89b00`, and `color: #ffe9a3`, and harmonized related dark-mode surfaces (table borders, link chips, nodes, and status blocks) for consistent contrast.
- Change is CSS-only and limited to `docs/gistau-ch15/visual_cards.css` to minimize risk and scope.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0c744f20b0832eb0b9e85f5ffd84aa)