### PR TITLE
Add A6 renderer governance foundation artifacts

### DIFF
--- a/governance/LAYOUT_CONTRACTS.yaml
+++ b/governance/LAYOUT_CONTRACTS.yaml
@@ -1,0 +1,13 @@
+version: 1
+layout_contracts:
+  min_padding: 24
+  max_text_width: 920
+  card_gap: 18
+  section_gap: 36
+  overflow_policy: scale_then_paginate
+
+constraints:
+  min_contrast_ratio: 4.5
+  max_heading_levels: 3
+  max_bullets_per_block: 7
+  orphan_bullet_min_following: 1

--- a/governance/LINEAGE_SCHEMA.yaml
+++ b/governance/LINEAGE_SCHEMA.yaml
@@ -1,0 +1,18 @@
+version: 1
+lineage_schema:
+  required:
+    - slide_id
+    - derived_from
+    - generated_outputs
+    - render_commit
+    - generated_at
+
+example:
+  slide_id: MSLIDE_ROOF_DECISION_01
+  derived_from:
+    pptx: QRB_AUB_ROOF(1).pptx
+    slide: 19
+  generated_outputs: [html, pdf, pptx]
+  render_commit:
+    git: 5ab91f2
+  generated_at: 2026-05-19T21:14:00Z

--- a/governance/RENDER_LINTER.py
+++ b/governance/RENDER_LINTER.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+RULES = [
+    "no_low_contrast",
+    "slide_id_required",
+]
+
+
+def run() -> int:
+    rc = 0
+    theme = Path("governance/SEMANTIC_THEME.yaml")
+    lineage = Path("governance/LINEAGE_SCHEMA.yaml")
+
+    if not theme.exists() or not lineage.exists():
+        print("FAIL: missing governance artifacts")
+        return 1
+
+    print("CHECK: no_low_contrast")
+    r1 = subprocess.run([sys.executable, "governance/WCAG_CONTRAST_CHECKER.py"], check=False)
+    rc |= r1.returncode
+
+    print("CHECK: slide_id_required (lineage example)")
+    r2 = subprocess.run(
+        [sys.executable, "governance/SLIDE_ID_ENFORCER.py", "governance/LINEAGE_SCHEMA.yaml"], check=False
+    )
+    rc |= r2.returncode
+
+    if rc == 0:
+        print("PASS: render linter checks passed")
+    else:
+        print("FAIL: render linter checks failed")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/governance/RENDER_RULES.md
+++ b/governance/RENDER_RULES.md
@@ -1,0 +1,27 @@
+# Render Governance Rules (A6)
+
+## Canonical Source Rule
+- **Generated outputs are never canonical**.
+- Canonical content must remain in source YAML/MD + figure registry.
+- Manual edits to generated PPTX/PDF/HTML are prohibited.
+
+## Determinism Rules
+- Given identical canonical input + renderer version + theme token set, output must be byte-stable where format allows.
+- All non-deterministic metadata (timestamps, random IDs) must be normalized.
+- Render jobs must emit lineage records.
+
+## Governance Gates
+- Render passes only if all lints pass:
+  - no_overflow
+  - no_low_contrast
+  - stable_heading_hierarchy
+  - figure_reference_required
+  - semantic_card_required
+  - slide_id_required
+
+## Exception Process
+- Any override requires:
+  1. reason
+  2. approver
+  3. expiry date
+  4. linked issue

--- a/governance/RENDER_TEST_SUITE.md
+++ b/governance/RENDER_TEST_SUITE.md
@@ -1,0 +1,17 @@
+# Render Governance Test Suite (A6)
+
+## Determinism
+- Re-render same input twice, compare normalized output checksums.
+
+## Layout
+- Verify `LAYOUT_CONTRACTS.yaml` thresholds are enforced.
+- Verify overflow policy (`scale_then_paginate`) behavior.
+
+## Contrast
+- Validate all semantic token fg/bg pairs against WCAG AA (>= 4.5).
+
+## Lineage
+- Ensure lineage artifacts include required schema keys.
+
+## Linting
+- Run `RENDER_LINTER.py` and fail CI on any violation.

--- a/governance/SEMANTIC_THEME.yaml
+++ b/governance/SEMANTIC_THEME.yaml
@@ -1,0 +1,21 @@
+version: 1
+name: semantic-theme
+
+semantic_tokens:
+  warning:
+    light: { bg: "#FFF4CC", fg: "#4A3A00", border: "#E6B800" }
+    dark:  { bg: "#3A2F00", fg: "#FFE28A", border: "#FFD24D" }
+
+  decision:
+    light: { bg: "#E8F2FF", fg: "#0E2A4D", border: "#2D6CC0" }
+    dark:  { bg: "#10243F", fg: "#BFD9FF", border: "#6CA8FF" }
+
+  reference:
+    light: { bg: "#F4F5F7", fg: "#1F2937", border: "#9CA3AF" }
+    dark:  { bg: "#1F2937", fg: "#E5E7EB", border: "#6B7280" }
+
+typography:
+  heading_1: { size: 42, weight: 700 }
+  heading_2: { size: 32, weight: 700 }
+  body: { size: 22, weight: 400 }
+  bullet: { size: 22, weight: 400 }

--- a/governance/SLIDE_ID_ENFORCER.py
+++ b/governance/SLIDE_ID_ENFORCER.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ID_PATTERN = re.compile(r"^MSLIDE_[A-Z0-9_]+_\d{2}$")
+
+
+def validate(path: str) -> int:
+    lines = Path(path).read_text().splitlines()
+    bad: list[str] = []
+    for i, line in enumerate(lines, start=1):
+        if line.strip().startswith("slide_id:"):
+            value = line.split(":", 1)[1].strip()
+            if not ID_PATTERN.match(value):
+                bad.append(f"{path}:{i} invalid slide_id '{value}'")
+
+    if bad:
+        print("\n".join(bad))
+        return 1
+
+    print(f"PASS: slide_id format valid in {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python governance/SLIDE_ID_ENFORCER.py <yaml-file>")
+        raise SystemExit(2)
+    raise SystemExit(validate(sys.argv[1]))

--- a/governance/WCAG_CONTRAST_CHECKER.py
+++ b/governance/WCAG_CONTRAST_CHECKER.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+HEX = re.compile(r"#[0-9A-Fa-f]{6}")
+
+
+def _hex_to_rgb(value: str) -> tuple[float, float, float]:
+    value = value.lstrip("#")
+    return int(value[0:2], 16) / 255, int(value[2:4], 16) / 255, int(value[4:6], 16) / 255
+
+
+def _linear(c: float) -> float:
+    return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def _luminance(hex_color: str) -> float:
+    r, g, b = _hex_to_rgb(hex_color)
+    return 0.2126 * _linear(r) + 0.7152 * _linear(g) + 0.0722 * _linear(b)
+
+
+def contrast_ratio(a: str, b: str) -> float:
+    la, lb = _luminance(a), _luminance(b)
+    lighter, darker = max(la, lb), min(la, lb)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def parse_fg_bg_pairs(text: str) -> list[tuple[str, str, str]]:
+    pairs: list[tuple[str, str, str]] = []
+    token = "unknown"
+    mode = "unknown"
+    for line in text.splitlines():
+        if re.match(r"^\s{2}[a-z_]+:\s*$", line):
+            token = line.strip().rstrip(":")
+        if re.match(r"^\s{4}(light|dark):", line):
+            mode = line.strip().split(":", 1)[0]
+            colors = HEX.findall(line)
+            if len(colors) >= 2:
+                pairs.append((f"{token}.{mode}", colors[0], colors[1]))
+    return pairs
+
+
+def main(path: str = "governance/SEMANTIC_THEME.yaml", minimum: float = 4.5) -> int:
+    text = Path(path).read_text()
+    errors = []
+    for key, bg, fg in parse_fg_bg_pairs(text):
+        ratio = contrast_ratio(bg, fg)
+        if ratio < minimum:
+            errors.append(f"{key}: contrast {ratio:.2f} < {minimum}")
+
+    if errors:
+        print("\n".join(f"FAIL: {e}" for e in errors))
+        return 1
+    print("PASS: all semantic token pairs satisfy WCAG threshold")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(*sys.argv[1:]))


### PR DESCRIPTION
### Motivation
- Establish a formal A6 “Renderer Governance Layer” to move from ad-hoc rendering toward deterministic, auditable publication outputs.
- Codify the rule that generated outputs are not canonical and require lineage, normalization, and lint gates before publishing.
- Provide baseline artifacts to enforce spacing, typography, contrast, slide identity, and exception governance for render pipelines.

### Description
- Add governance docs and schemas: `governance/RENDER_RULES.md`, `governance/SEMANTIC_THEME.yaml`, `governance/LAYOUT_CONTRACTS.yaml`, `governance/LINEAGE_SCHEMA.yaml`, and `governance/RENDER_TEST_SUITE.md` to capture policies and contracts.
- Add automated checks: `governance/WCAG_CONTRAST_CHECKER.py` to validate semantic token contrast, and `governance/SLIDE_ID_ENFORCER.py` to enforce `slide_id` naming conventions.
- Add an orchestration linter `governance/RENDER_LINTER.py` that runs the governance checks and fails when required artifacts or rules are missing.
- Define deterministic rendering expectations and governance gates (lint rules and exception process) in `RENDER_RULES.md` and layout/typography thresholds in `LAYOUT_CONTRACTS.yaml` and `SEMANTIC_THEME.yaml`.

### Testing
- Ran `python governance/WCAG_CONTRAST_CHECKER.py` and it passed for the provided `SEMANTIC_THEME.yaml`.
- Ran `python governance/SLIDE_ID_ENFORCER.py governance/LINEAGE_SCHEMA.yaml` and it passed slide id validation for the example lineage record.
- Ran `python governance/RENDER_LINTER.py` which invoked the checks and reported all governance checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0c7552fee4832e8a5c6fc5ae609906)