### PR TITLE
feat(g3): add G3 deep-tuple matrix and orchestration scripts

### DIFF
--- a/g3_deep_matrix.json
+++ b/g3_deep_matrix.json
@@ -1,0 +1,57 @@
+{
+  "generation": "G3",
+  "system_owner": "Gert",
+  "project_parent": "MINERVA",
+  "federation_bridge": {
+    "upstream_anchor": "gbogeb/codex",
+    "downstream_anchor": "gbogeb/abacus"
+  },
+  "tuples": [
+    {
+      "component_id": "G3-TUPLE-A66",
+      "domain": "Control & Automation",
+      "scope": "A66 Module Development Status",
+      "lifecycle_level": "L4-Detailed-Design",
+      "upstream": {
+        "repo": "gbogeb/codex",
+        "file_path": "components/a66/specs.md",
+        "validation_schema": "schemas/a66_definition.yaml"
+      },
+      "downstream": {
+        "repo": "gbogeb/abacus",
+        "file_path": "controllers/a66_logic.py",
+        "test_suite": "tests/test_a66.py"
+      }
+    },
+    {
+      "component_id": "G3-TUPLE-HE-REF",
+      "domain": "Cryogenic System Engineering",
+      "scope": "Helium Refrigeration System",
+      "lifecycle_level": "L5-Manufacturing-Integration",
+      "upstream": {
+        "repo": "gbogeb/codex",
+        "file_path": "cryo/helium_refrigeration_requirements.md",
+        "modes": ["2K-SB", "2K-OP"]
+      },
+      "downstream": {
+        "repo": "gbogeb/abacus",
+        "file_path": "physics/helium_refrigeration_core.py",
+        "analytical_checks": ["Exergy", "ANOVA_Variance", "PCA_Waves"]
+      }
+    },
+    {
+      "component_id": "G3-TUPLE-GH-PR",
+      "domain": "CI/CD DevOps Infrastructure",
+      "scope": "GitHub PR Generation & Branch Verification",
+      "lifecycle_level": "L8-Integrated-Commissioning",
+      "upstream": {
+        "repo": "gbogeb/codex",
+        "file_path": ".github/workflows/g3_gatekeeper.yml"
+      },
+      "downstream": {
+        "repo": "gbogeb/abacus",
+        "file_path": "automation/pr_generator.py"
+      }
+    }
+  ]
+}

--- a/g3_deep_matrix.json
+++ b/g3_deep_matrix.json
@@ -14,8 +14,8 @@
       "lifecycle_level": "L4-Detailed-Design",
       "upstream": {
         "repo": "gbogeb/codex",
-        "file_path": "components/a66/specs.md",
-        "validation_schema": "schemas/a66_definition.yaml"
+        "file_path": "traceability/TRACEABILITY_MATRIX.md",
+        "validation_schema": "01_requirements/requirements.json"
       },
       "downstream": {
         "repo": "gbogeb/abacus",
@@ -30,7 +30,7 @@
       "lifecycle_level": "L5-Manufacturing-Integration",
       "upstream": {
         "repo": "gbogeb/codex",
-        "file_path": "cryo/helium_refrigeration_requirements.md",
+        "file_path": "VCR_Requirements.md",
         "modes": ["2K-SB", "2K-OP"]
       },
       "downstream": {
@@ -46,7 +46,7 @@
       "lifecycle_level": "L8-Integrated-Commissioning",
       "upstream": {
         "repo": "gbogeb/codex",
-        "file_path": ".github/workflows/g3_gatekeeper.yml"
+        "file_path": ".github/workflows/ci.yml"
       },
       "downstream": {
         "repo": "gbogeb/abacus",

--- a/helium_refrigeration_core.py
+++ b/helium_refrigeration_core.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import numpy as np
+
+
+class CryogenicHeliumEngine:
+    def __init__(self, t0_ambient=298.15):
+        self.T0 = t0_ambient
+        self.modes = {
+            "2K-SB": {"description": "Static Heat Load Benchmark", "target_temp": 2.0},
+            "2K-OP": {"description": "Dynamic Load Operational Mode", "target_temp": 2.0},
+        }
+
+    def compute_exergy_efficiency(
+        self,
+        mass_flow,
+        enthalpy_in,
+        enthalpy_out,
+        entropy_in,
+        entropy_out,
+        power_kw,
+    ):
+        delta_h = enthalpy_out - enthalpy_in
+        delta_s = entropy_out - entropy_in
+        exergy_change = delta_h - (self.T0 * delta_s)
+        useful_exergy_power = mass_flow * exergy_change
+
+        if power_kw <= 0:
+            return 0.0
+        return min(max(useful_exergy_power / power_kw, 0.0), 1.0)
+
+    def calculate_anova_variance(self, claimed_vector, actual_vector):
+        c = np.array(claimed_vector, dtype=float)
+        a = np.array(actual_vector, dtype=float)
+        if len(c) != len(a) or len(c) < 2:
+            return 0.0
+        covariance_matrix = np.cov(c, a)
+        return float(covariance_matrix[0, 1])

--- a/helium_refrigeration_core.py
+++ b/helium_refrigeration_core.py
@@ -30,7 +30,8 @@ class CryogenicHeliumEngine:
 
         if power_kw <= 0:
             return 0.0
-        return min(max(useful_exergy_power / power_kw, 0.0), 1.0)
+        power_w = power_kw * 1000.0
+        return min(max(useful_exergy_power / power_w, 0.0), 1.0)
 
     def calculate_covariance(self, claimed_vector, actual_vector):
         c = [float(value) for value in claimed_vector]
@@ -46,4 +47,14 @@ class CryogenicHeliumEngine:
         return float(covariance)
 
     def calculate_anova_variance(self, claimed_vector, actual_vector):
-        return self.calculate_covariance(claimed_vector, actual_vector)
+        c = [float(value) for value in claimed_vector]
+        a = [float(value) for value in actual_vector]
+        if len(c) != len(a) or len(c) < 2:
+            return 0.0
+
+        residuals = [claimed - actual for claimed, actual in zip(c, a)]
+        residual_mean = sum(residuals) / len(residuals)
+        variance = sum((value - residual_mean) ** 2 for value in residuals) / (
+            len(residuals) - 1
+        )
+        return float(variance)

--- a/helium_refrigeration_core.py
+++ b/helium_refrigeration_core.py
@@ -30,8 +30,8 @@ class CryogenicHeliumEngine:
 
         if power_kw <= 0:
             return 0.0
-        power_w = power_kw * 1000.0
-        return min(max(useful_exergy_power / power_w, 0.0), 1.0)
+        power_watts = power_kw * 1000.0
+        return min(max(useful_exergy_power / power_watts, 0.0), 1.0)
 
     def calculate_covariance(self, claimed_vector, actual_vector):
         c = [float(value) for value in claimed_vector]

--- a/helium_refrigeration_core.py
+++ b/helium_refrigeration_core.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import numpy as np
+from src.gistau_ch15.kernels.exergy import specific_flow_exergy
 
 
 class CryogenicHeliumEngine:
@@ -19,19 +19,31 @@ class CryogenicHeliumEngine:
         entropy_out,
         power_kw,
     ):
-        delta_h = enthalpy_out - enthalpy_in
-        delta_s = entropy_out - entropy_in
-        exergy_change = delta_h - (self.T0 * delta_s)
+        exergy_change = specific_flow_exergy(
+            h_j_kg=enthalpy_out,
+            s_j_kgk=entropy_out,
+            h0_j_kg=enthalpy_in,
+            s0_j_kgk=entropy_in,
+            t0_k=self.T0,
+        )
         useful_exergy_power = mass_flow * exergy_change
 
         if power_kw <= 0:
             return 0.0
         return min(max(useful_exergy_power / power_kw, 0.0), 1.0)
 
-    def calculate_anova_variance(self, claimed_vector, actual_vector):
-        c = np.array(claimed_vector, dtype=float)
-        a = np.array(actual_vector, dtype=float)
+    def calculate_covariance(self, claimed_vector, actual_vector):
+        c = [float(value) for value in claimed_vector]
+        a = [float(value) for value in actual_vector]
         if len(c) != len(a) or len(c) < 2:
             return 0.0
-        covariance_matrix = np.cov(c, a)
-        return float(covariance_matrix[0, 1])
+
+        c_mean = sum(c) / len(c)
+        a_mean = sum(a) / len(a)
+        covariance = sum(
+            (claimed - c_mean) * (actual - a_mean) for claimed, actual in zip(c, a)
+        ) / (len(c) - 1)
+        return float(covariance)
+
+    def calculate_anova_variance(self, claimed_vector, actual_vector):
+        return self.calculate_covariance(claimed_vector, actual_vector)

--- a/helium_refrigeration_core.py
+++ b/helium_refrigeration_core.py
@@ -52,9 +52,9 @@ class CryogenicHeliumEngine:
         if len(c) != len(a) or len(c) < 2:
             return 0.0
 
-        residuals = [claimed - actual for claimed, actual in zip(c, a)]
-        residual_mean = sum(residuals) / len(residuals)
-        variance = sum((value - residual_mean) ** 2 for value in residuals) / (
-            len(residuals) - 1
+        differences = [claimed - actual for claimed, actual in zip(c, a)]
+        difference_mean = sum(differences) / len(differences)
+        variance = sum((value - difference_mean) ** 2 for value in differences) / (
+            len(differences) - 1
         )
         return float(variance)

--- a/orchestrate_g3.py
+++ b/orchestrate_g3.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import json
+from html import escape
 from pathlib import Path
+from urllib.parse import quote
 
 from helium_refrigeration_core import CryogenicHeliumEngine
 
@@ -11,7 +13,9 @@ def _load_matrix(matrix_path: Path) -> dict:
 
 
 def _upstream_url(repo: str, file_path: str) -> str:
-    return f"https://github.com/{repo}/blob/main/{file_path}"
+    safe_repo = quote(repo, safe="/._-")
+    safe_path = quote(file_path, safe="/._-")
+    return f"https://github.com/{safe_repo}/blob/main/{safe_path}"
 
 
 def compile_g3_dashboard():
@@ -40,12 +44,17 @@ def compile_g3_dashboard():
     for tuple_data in matrix.get("tuples", []):
         upstream_repo = tuple_data["upstream"]["repo"]
         upstream_file = tuple_data["upstream"]["file_path"]
+        component_id = escape(str(tuple_data["component_id"]))
+        scope = escape(str(tuple_data["scope"]))
+        upstream_file_display = escape(str(upstream_file))
+        downstream_file = escape(str(tuple_data["downstream"]["file_path"]))
+        upstream_url = escape(_upstream_url(upstream_repo, upstream_file), quote=True)
         tuple_rows.append(
             "<tr>"
-            f"<td>{tuple_data['component_id']}</td>"
-            f"<td>{tuple_data['scope']}</td>"
-            f"<td><a href=\"{_upstream_url(upstream_repo, upstream_file)}\">{upstream_file}</a></td>"
-            f"<td>{tuple_data['downstream']['file_path']}</td>"
+            f"<td>{component_id}</td>"
+            f"<td>{scope}</td>"
+            f"<td><a href=\"{upstream_url}\">{upstream_file_display}</a></td>"
+            f"<td>{downstream_file}</td>"
             "</tr>"
         )
         if upstream_repo.lower() == "gbogeb/codex" and not (repo_root / upstream_file).exists():

--- a/orchestrate_g3.py
+++ b/orchestrate_g3.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 import json
+import re
 from html import escape
 from pathlib import Path
 from urllib.parse import quote
 
 from helium_refrigeration_core import CryogenicHeliumEngine
+
+
+_REPO_SLUG_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
 def _load_matrix(matrix_path: Path) -> dict:
@@ -13,7 +17,9 @@ def _load_matrix(matrix_path: Path) -> dict:
 
 
 def _upstream_url(repo: str, file_path: str) -> str:
-    safe_repo = quote(repo, safe="/._-")
+    if not _REPO_SLUG_PATTERN.fullmatch(repo):
+        return "#"
+    safe_repo = repo
     safe_path = quote(file_path, safe="/._-")
     return f"https://github.com/{safe_repo}/blob/main/{safe_path}"
 

--- a/orchestrate_g3.py
+++ b/orchestrate_g3.py
@@ -1,14 +1,31 @@
 #!/usr/bin/env python3
+import json
+from pathlib import Path
+
 from helium_refrigeration_core import CryogenicHeliumEngine
 
 
+def _load_matrix(matrix_path: Path) -> dict:
+    with matrix_path.open("r", encoding="utf-8") as matrix_file:
+        return json.load(matrix_file)
+
+
+def _upstream_url(repo: str, file_path: str) -> str:
+    return f"https://github.com/{repo}/blob/main/{file_path}"
+
+
 def compile_g3_dashboard():
+    repo_root = Path(__file__).resolve().parent
+    output_dir = repo_root / "outputs" / "html"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
     engine = CryogenicHeliumEngine()
+    matrix = _load_matrix(repo_root / "g3_deep_matrix.json")
 
     claimed_waves = [0.20, 0.40, 0.60, 0.80, 1.00]
     actual_waves = [0.18, 0.39, 0.55, 0.79, 0.98]
 
-    anova_covariance = engine.calculate_anova_variance(claimed_waves, actual_waves)
+    covariance = engine.calculate_covariance(claimed_waves, actual_waves)
     exergy_sample = engine.compute_exergy_efficiency(
         mass_flow=11.5,
         enthalpy_in=10.5,
@@ -16,6 +33,28 @@ def compile_g3_dashboard():
         entropy_in=0.05,
         entropy_out=0.08,
         power_kw=250.0,
+    )
+
+    tuple_rows = []
+    missing_upstream_paths = []
+    for tuple_data in matrix.get("tuples", []):
+        upstream_repo = tuple_data["upstream"]["repo"]
+        upstream_file = tuple_data["upstream"]["file_path"]
+        tuple_rows.append(
+            "<tr>"
+            f"<td>{tuple_data['component_id']}</td>"
+            f"<td>{tuple_data['scope']}</td>"
+            f"<td><a href=\"{_upstream_url(upstream_repo, upstream_file)}\">{upstream_file}</a></td>"
+            f"<td>{tuple_data['downstream']['file_path']}</td>"
+            "</tr>"
+        )
+        if upstream_repo.lower() == "gbogeb/codex" and not (repo_root / upstream_file).exists():
+            missing_upstream_paths.append(upstream_file)
+
+    missing_todo_lines = (
+        "\n".join(f"- [ ] Add or correct upstream anchor: `{path}`" for path in missing_upstream_paths)
+        if missing_upstream_paths
+        else "- [x] All codex upstream anchors currently resolve to existing files."
     )
 
     files_html = f"""<!DOCTYPE html>
@@ -27,9 +66,7 @@ def compile_g3_dashboard():
     <h2>📁 G3 Deep-Tuple File Topography Lineage Map</h2>
     <table>
         <tr><th>Tuple ID</th><th>Scope Context Block</th><th>Upstream (codex)</th><th>Downstream (abacus)</th></tr>
-        <tr><td>G3-TUPLE-A66</td><td>A66 Development Status</td><td><a href=\"https://github.com/gbogeb/codex\">components/a66/specs.md</a></td><td>controllers/a66_logic.py</td></tr>
-        <tr><td>G3-TUPLE-HE-REF</td><td>Helium Refrigeration Core</td><td>cryo/helium_refrigeration_requirements.md</td><td>physics/helium_refrigeration_core.py</td></tr>
-        <tr><td>G3-TUPLE-GH-PR</td><td>GitHub Pull Request Engine</td><td>.github/workflows/g3_gatekeeper.yml</td><td>automation/pr_generator.py</td></tr>
+        {''.join(tuple_rows)}
     </table>
 </body>
 </html>"""
@@ -43,7 +80,7 @@ def compile_g3_dashboard():
     <h1>📊 G3 Real-Time Wave Telemetry Dashboard</h1>
     <div>A66 Module Status: L4 Verified</div>
     <div>Helium Loop Exergy Efficiency: {exergy_sample*100:.2f}%</div>
-    <div>ANOVA Covariance Metric: {anova_covariance:.6f}</div>
+    <div>Wave Covariance Metric: {covariance:.6f}</div>
 </body>
 </html>"""
 
@@ -59,20 +96,23 @@ def compile_g3_dashboard():
 This platform maps high-level layouts inside **gbogeb/codex** directly to the functional mathematical code engines inside **gbogeb/abacus**.
 
 ### 📈 Current Automated Pipeline Health Metrics
-* **Calculated ANOVA Covariance Parameter:** `{anova_covariance:.6f}`
+* **Calculated Wave Covariance Parameter:** `{covariance:.6f}`
 * **Helium Cycle System Exergy Rating:** `{exergy_sample * 100:.2f}%`
 * **Core Development Configuration Track Status:** `G3-Verified Stable Production`
+
+## TODO: Missing Build-Out Anchors
+{missing_todo_lines}
 """
 
-    with open("files.html", "w", encoding="utf-8") as f:
+    with (output_dir / "files.html").open("w", encoding="utf-8") as f:
         f.write(files_html)
-    with open("dashboard.html", "w", encoding="utf-8") as f:
+    with (output_dir / "dashboard.html").open("w", encoding="utf-8") as f:
         f.write(dashboard_html)
-    with open("slides_html.html", "w", encoding="utf-8") as f:
+    with (output_dir / "slides_html.html").open("w", encoding="utf-8") as f:
         f.write(slides_html)
-    with open("README.md", "w", encoding="utf-8") as f:
+    with (output_dir / "README.md").open("w", encoding="utf-8") as f:
         f.write(readme_md)
-    print("✨ Process Success: All 4 production target artifacts compiled and verified for G3.")
+    print(f"✨ Process Success: All 4 production target artifacts compiled to {output_dir}.")
 
 
 if __name__ == "__main__":

--- a/orchestrate_g3.py
+++ b/orchestrate_g3.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from helium_refrigeration_core import CryogenicHeliumEngine
+
+
+def compile_g3_dashboard():
+    engine = CryogenicHeliumEngine()
+
+    claimed_waves = [0.20, 0.40, 0.60, 0.80, 1.00]
+    actual_waves = [0.18, 0.39, 0.55, 0.79, 0.98]
+
+    anova_covariance = engine.calculate_anova_variance(claimed_waves, actual_waves)
+    exergy_sample = engine.compute_exergy_efficiency(
+        mass_flow=11.5,
+        enthalpy_in=10.5,
+        enthalpy_out=25.0,
+        entropy_in=0.05,
+        entropy_out=0.08,
+        power_kw=250.0,
+    )
+
+    files_html = f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+    <meta charset=\"UTF-8\"><title>G3 File Topography</title>
+</head>
+<body>
+    <h2>📁 G3 Deep-Tuple File Topography Lineage Map</h2>
+    <table>
+        <tr><th>Tuple ID</th><th>Scope Context Block</th><th>Upstream (codex)</th><th>Downstream (abacus)</th></tr>
+        <tr><td>G3-TUPLE-A66</td><td>A66 Development Status</td><td><a href=\"https://github.com/gbogeb/codex\">components/a66/specs.md</a></td><td>controllers/a66_logic.py</td></tr>
+        <tr><td>G3-TUPLE-HE-REF</td><td>Helium Refrigeration Core</td><td>cryo/helium_refrigeration_requirements.md</td><td>physics/helium_refrigeration_core.py</td></tr>
+        <tr><td>G3-TUPLE-GH-PR</td><td>GitHub Pull Request Engine</td><td>.github/workflows/g3_gatekeeper.yml</td><td>automation/pr_generator.py</td></tr>
+    </table>
+</body>
+</html>"""
+
+    dashboard_html = f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+    <meta charset=\"UTF-8\"><title>G3 Telemetry Dashboard</title>
+</head>
+<body>
+    <h1>📊 G3 Real-Time Wave Telemetry Dashboard</h1>
+    <div>A66 Module Status: L4 Verified</div>
+    <div>Helium Loop Exergy Efficiency: {exergy_sample*100:.2f}%</div>
+    <div>ANOVA Covariance Metric: {anova_covariance:.6f}</div>
+</body>
+</html>"""
+
+    slides_html = """<!DOCTYPE html>
+<html lang=\"en\">
+<head><meta charset=\"UTF-8\"><title>G3 Systems Architecture Slides</title></head>
+<body><h1>Generation 3 (G3) System Integration Matrix</h1></body>
+</html>"""
+
+    readme_md = f"""# 🌌 Exhaustive Generation 3 (G3) System Control Interface
+
+## 🏗️ Deep-Tuple System Cross-Repository Connections
+This platform maps high-level layouts inside **gbogeb/codex** directly to the functional mathematical code engines inside **gbogeb/abacus**.
+
+### 📈 Current Automated Pipeline Health Metrics
+* **Calculated ANOVA Covariance Parameter:** `{anova_covariance:.6f}`
+* **Helium Cycle System Exergy Rating:** `{exergy_sample * 100:.2f}%`
+* **Core Development Configuration Track Status:** `G3-Verified Stable Production`
+"""
+
+    with open("files.html", "w", encoding="utf-8") as f:
+        f.write(files_html)
+    with open("dashboard.html", "w", encoding="utf-8") as f:
+        f.write(dashboard_html)
+    with open("slides_html.html", "w", encoding="utf-8") as f:
+        f.write(slides_html)
+    with open("README.md", "w", encoding="utf-8") as f:
+        f.write(readme_md)
+    print("✨ Process Success: All 4 production target artifacts compiled and verified for G3.")
+
+
+if __name__ == "__main__":
+    compile_g3_dashboard()

--- a/pr_generator.py
+++ b/pr_generator.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+import requests
+
+
+def issue_g3_pull_request(repo_slug, head_branch, pr_title, pr_body_markdown):
+    token = os.getenv("GITHUB_TOKEN")
+    if not token:
+        print("⚠️ Secret GITHUB_TOKEN environment variable is unassigned. Skipping PR generation.")
+        return False
+
+    url = f"https://api.github.com/repos/{repo_slug}/pulls"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    payload = {
+        "title": pr_title,
+        "body": pr_body_markdown,
+        "head": head_branch,
+        "base": "main",
+        "maintainer_can_modify": True,
+    }
+
+    response = requests.post(url, json=payload, headers=headers, timeout=30)
+    if response.status_code == 201:
+        print(f"🚀 Pull Request opened successfully: {response.json().get('html_url')}")
+        return True
+
+    print(f"❌ API Pull Request initialization failed Error {response.status_code}: {response.text}")
+    return False
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--trigger":
+        sample_body = """### 🤖 G3 Continuous Delivery Synchronization
+* **Module Scope:** Deep alignment validation across A66 and Helium Cryo units.
+* **Verification Anchor:** ANOVA Covariance Matrix and Exergy calculations validated successfully.
+        """
+        issue_g3_pull_request(
+            "gbogeb/abacus",
+            "feature/g3-system-update",
+            "chore(g3): execute deep-tuple synchronization",
+            sample_body,
+        )

--- a/pr_generator.py
+++ b/pr_generator.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 import requests
+from src.github_interface import GitHubInterface
 
 
 def issue_g3_pull_request(repo_slug, head_branch, pr_title, pr_body_markdown):
@@ -11,12 +12,9 @@ def issue_g3_pull_request(repo_slug, head_branch, pr_title, pr_body_markdown):
         print("⚠️ Secret GITHUB_TOKEN environment variable is unassigned. Skipping PR generation.")
         return False
 
-    url = f"https://api.github.com/repos/{repo_slug}/pulls"
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
+    github = GitHubInterface()
+    url = f"{github.api_url}/repos/{repo_slug}/pulls"
+    headers = github.get_api_headers(token)
     payload = {
         "title": pr_title,
         "body": pr_body_markdown,
@@ -25,7 +23,11 @@ def issue_g3_pull_request(repo_slug, head_branch, pr_title, pr_body_markdown):
         "maintainer_can_modify": True,
     }
 
-    response = requests.post(url, json=payload, headers=headers, timeout=30)
+    try:
+        response = requests.post(url, json=payload, headers=headers, timeout=30)
+    except requests.RequestException as exc:
+        print(f"❌ API Pull Request initialization transport error: {exc}")
+        return False
     if response.status_code == 201:
         print(f"🚀 Pull Request opened successfully: {response.json().get('html_url')}")
         return True

--- a/tests/test_g3_scripts.py
+++ b/tests/test_g3_scripts.py
@@ -38,7 +38,7 @@ def test_compute_exergy_efficiency_bounds() -> None:
     )
 
 
-def test_covariance_and_legacy_alias() -> None:
+def test_covariance_and_variance_metrics() -> None:
     engine = CryogenicHeliumEngine()
     claimed = [1.0, 2.0, 3.0]
     actual = [1.0, 2.0, 3.0]
@@ -91,6 +91,32 @@ def test_compile_g3_dashboard_notes_missing_anchors(
     files_html = (tmp_path / "outputs" / "html" / "files.html").read_text(encoding="utf-8")
     assert "- [ ] Add or correct upstream anchor: `missing.md`" in readme
     assert "G3-TUPLE-ONE" in files_html
+
+
+def test_compile_g3_dashboard_escapes_matrix_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    matrix = {
+        "tuples": [
+            {
+                "component_id": "<script>alert(1)</script>",
+                "scope": "Scope & \"quoted\"",
+                "upstream": {"repo": "gbogeb/codex", "file_path": "a b/<tag>.md"},
+                "downstream": {"file_path": "downstream/<bad>.py"},
+            }
+        ]
+    }
+    (tmp_path / "g3_deep_matrix.json").write_text(json.dumps(matrix), encoding="utf-8")
+    monkeypatch.setattr(orchestrate_g3, "__file__", str(tmp_path / "orchestrate_g3.py"))
+
+    orchestrate_g3.compile_g3_dashboard()
+
+    files_html = (tmp_path / "outputs" / "html" / "files.html").read_text(encoding="utf-8")
+    assert "<script>alert(1)</script>" not in files_html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in files_html
+    assert "Scope &amp; &quot;quoted&quot;" in files_html
+    assert "a%20b/%3Ctag%3E.md" in files_html
+    assert "downstream/&lt;bad&gt;.py" in files_html
 
 
 def test_issue_g3_pull_request_handles_transport_errors(

--- a/tests/test_g3_scripts.py
+++ b/tests/test_g3_scripts.py
@@ -101,7 +101,10 @@ def test_compile_g3_dashboard_escapes_matrix_values(
             {
                 "component_id": "<script>alert(1)</script>",
                 "scope": "Scope & \"quoted\"",
-                "upstream": {"repo": "gbogeb/codex", "file_path": "a b/<tag>.md"},
+                "upstream": {
+                    "repo": "gbogeb/codex\" onclick=\"alert(1)",
+                    "file_path": "a b/<tag>.md",
+                },
                 "downstream": {"file_path": "downstream/<bad>.py"},
             }
         ]
@@ -115,7 +118,9 @@ def test_compile_g3_dashboard_escapes_matrix_values(
     assert "<script>alert(1)</script>" not in files_html
     assert "&lt;script&gt;alert(1)&lt;/script&gt;" in files_html
     assert "Scope &amp; &quot;quoted&quot;" in files_html
-    assert "a%20b/%3Ctag%3E.md" in files_html
+    assert "onclick=&quot;alert(1)" not in files_html
+    assert "href=\"#\"" in files_html
+    assert "a b/&lt;tag&gt;.md" in files_html
     assert "downstream/&lt;bad&gt;.py" in files_html
 
 

--- a/tests/test_g3_scripts.py
+++ b/tests/test_g3_scripts.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import requests
+
+import orchestrate_g3
+import pr_generator
+from helium_refrigeration_core import CryogenicHeliumEngine
+
+
+def test_compute_exergy_efficiency_bounds() -> None:
+    engine = CryogenicHeliumEngine()
+
+    assert (
+        engine.compute_exergy_efficiency(
+            mass_flow=1.0,
+            enthalpy_in=100.0,
+            enthalpy_out=130.0,
+            entropy_in=1.0,
+            entropy_out=1.1,
+            power_kw=0.0,
+        )
+        == 0.0
+    )
+    assert (
+        engine.compute_exergy_efficiency(
+            mass_flow=10.0,
+            enthalpy_in=100.0,
+            enthalpy_out=220.0,
+            entropy_in=1.0,
+            entropy_out=1.1,
+            power_kw=1.0,
+        )
+        == 1.0
+    )
+
+
+def test_covariance_and_legacy_alias() -> None:
+    engine = CryogenicHeliumEngine()
+    claimed = [1.0, 2.0, 3.0]
+    actual = [1.0, 2.0, 3.0]
+
+    assert engine.calculate_covariance(claimed, actual) == pytest.approx(1.0)
+    assert engine.calculate_anova_variance(claimed, actual) == pytest.approx(1.0)
+    assert engine.calculate_covariance([1.0], [1.0]) == 0.0
+
+
+def test_compile_g3_dashboard_notes_missing_anchors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    matrix = {
+        "tuples": [
+            {
+                "component_id": "G3-TUPLE-ONE",
+                "scope": "Scope One",
+                "upstream": {"repo": "gbogeb/codex", "file_path": "exists.md"},
+                "downstream": {"file_path": "downstream/one.py"},
+            },
+            {
+                "component_id": "G3-TUPLE-TWO",
+                "scope": "Scope Two",
+                "upstream": {"repo": "gbogeb/codex", "file_path": "missing.md"},
+                "downstream": {"file_path": "downstream/two.py"},
+            },
+        ]
+    }
+    (tmp_path / "exists.md").write_text("ok", encoding="utf-8")
+    (tmp_path / "g3_deep_matrix.json").write_text(json.dumps(matrix), encoding="utf-8")
+    monkeypatch.setattr(orchestrate_g3, "__file__", str(tmp_path / "orchestrate_g3.py"))
+
+    orchestrate_g3.compile_g3_dashboard()
+
+    readme = (tmp_path / "outputs" / "html" / "README.md").read_text(encoding="utf-8")
+    files_html = (tmp_path / "outputs" / "html" / "files.html").read_text(encoding="utf-8")
+    assert "- [ ] Add or correct upstream anchor: `missing.md`" in readme
+    assert "G3-TUPLE-ONE" in files_html
+
+
+def test_issue_g3_pull_request_handles_transport_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "dummy")
+
+    def _raise_request_exception(*_args, **_kwargs):
+        raise requests.RequestException("network down")
+
+    monkeypatch.setattr(pr_generator.requests, "post", _raise_request_exception)
+    assert (
+        pr_generator.issue_g3_pull_request(
+            "GBOGEB/CODEX", "branch", "title", "body"
+        )
+        is False
+    )

--- a/tests/test_g3_scripts.py
+++ b/tests/test_g3_scripts.py
@@ -90,7 +90,7 @@ def test_issue_g3_pull_request_handles_transport_errors(
     monkeypatch.setattr(pr_generator.requests, "post", _raise_request_exception)
     assert (
         pr_generator.issue_g3_pull_request(
-            "GBOGEB/CODEX", "branch", "title", "body"
+            "gbogeb/codex", "branch", "title", "body"
         )
         is False
     )

--- a/tests/test_g3_scripts.py
+++ b/tests/test_g3_scripts.py
@@ -32,7 +32,7 @@ def test_compute_exergy_efficiency_bounds() -> None:
             enthalpy_out=220.0,
             entropy_in=1.0,
             entropy_out=1.1,
-            power_kw=1.0,
+            power_kw=0.5,
         )
         == 1.0
     )
@@ -44,8 +44,22 @@ def test_covariance_and_legacy_alias() -> None:
     actual = [1.0, 2.0, 3.0]
 
     assert engine.calculate_covariance(claimed, actual) == pytest.approx(1.0)
-    assert engine.calculate_anova_variance(claimed, actual) == pytest.approx(1.0)
+    assert engine.calculate_anova_variance(claimed, actual) == pytest.approx(0.0)
     assert engine.calculate_covariance([1.0], [1.0]) == 0.0
+    assert engine.calculate_anova_variance([1.0], [1.0]) == 0.0
+
+
+def test_compute_exergy_efficiency_uses_kw_units() -> None:
+    engine = CryogenicHeliumEngine()
+    efficiency = engine.compute_exergy_efficiency(
+        mass_flow=2.0,
+        enthalpy_in=100.0,
+        enthalpy_out=1100.0,
+        entropy_in=1.0,
+        entropy_out=1.0,
+        power_kw=2.0,
+    )
+    assert efficiency == pytest.approx(1.0)
 
 
 def test_compile_g3_dashboard_notes_missing_anchors(


### PR DESCRIPTION
### Motivation

- Provide a canonical, machine-readable deep-tuple Requirements Traceability Matrix to map upstream/downstream components for the G3 delivery model.
- Implement a small thermodynamic analytics engine to compute exergy and covariance metrics for helium refrigeration verification.
- Add an automated PR helper to enable pipeline-driven GitHub PR creation with a token-guarded execution path.
- Provide an orchestration script that bakes four deployable artifacts from the computed metrics for downstream consumption.

### Description

- Add `g3_deep_matrix.json` containing the G3 tuple matrix and upstream/downstream anchors for A66, helium refrigeration, and PR automation.
- Add `helium_refrigeration_core.py` implementing `CryogenicHeliumEngine` with `compute_exergy_efficiency` and `calculate_anova_variance` helpers that depend on `numpy`.
- Add `pr_generator.py` implementing `issue_g3_pull_request(repo_slug, head_branch, pr_title, pr_body_markdown)` guarded by the `GITHUB_TOKEN` environment variable and a `--trigger` CLI path.
- Add `orchestrate_g3.py` which instantiates the engine, computes sample metrics, and writes `files.html`, `dashboard.html`, `slides_html.html`, and `README.md` as the four target artifacts.

### Testing

- `python3 -m py_compile helium_refrigeration_core.py pr_generator.py orchestrate_g3.py` completed successfully.
- Running `python3 orchestrate_g3.py` in the current environment failed with `ModuleNotFoundError: No module named 'numpy'` because `numpy` is not installed.
- The GitHub PR path in `pr_generator.py` was not executed because `GITHUB_TOKEN` is not set in this environment, so no external API calls were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a131eefce80832ea5421213fff49b7a)