### PR TITLE
A6 - Add WCAG contrast validation engine

### DIFF
--- a/semantic_substrate/renderer/contrast_validator.py
+++ b/semantic_substrate/renderer/contrast_validator.py
@@ -33,7 +33,7 @@ def _load_warning_dark_invariant() -> dict[str, str]:
 
 class ContrastValidator:
     """
-    G5 Hardened WCAG 2.1 Luminance and Relative Contrast Ratio Validation Engine.
+    A6 WCAG 2.1 luminance and relative contrast ratio validation engine.
     Enforces semantic theme safety constraints for the ABACUS_RENDER_PIPELINE.
     """
 

--- a/semantic_substrate/renderer/contrast_validator.py
+++ b/semantic_substrate/renderer/contrast_validator.py
@@ -17,7 +17,11 @@ def _load_warning_dark_invariant() -> dict[str, str]:
             f"Invalid YAML in {theme_path}: expected root mapping/dictionary."
         )
     semantic_cards = data.get("semantic_cards", {})
+    if not isinstance(semantic_cards, dict):
+        raise ValueError(f"Invalid semantic_cards mapping in {theme_path}.")
     warning = semantic_cards.get("warning", {})
+    if not isinstance(warning, dict):
+        raise ValueError(f"Invalid warning mapping in {theme_path}.")
     warning_dark = warning.get("dark", {})
     if not isinstance(warning_dark, dict):
         raise ValueError(f"Invalid warning.dark mapping in {theme_path}.")

--- a/semantic_substrate/renderer/contrast_validator.py
+++ b/semantic_substrate/renderer/contrast_validator.py
@@ -20,9 +20,7 @@ def _load_warning_dark_invariant() -> dict[str, str]:
     warning = semantic_cards.get("warning", {})
     warning_dark = warning.get("dark", {})
     if not isinstance(warning_dark, dict):
-        raise ValueError(
-            f"Invalid warning.dark mapping in {theme_path}: expected dictionary."
-        )
+        raise ValueError(f"Invalid warning.dark mapping in {theme_path}.")
     if "background" not in warning_dark or "text" not in warning_dark:
         raise ValueError(
             f"Missing required warning.dark colors in {theme_path}: "
@@ -57,14 +55,12 @@ class ContrastValidator:
             raise ValueError(f"Unsupported hex color '{value}'")
         if len(value) == 4:
             value = "#" + "".join(ch * 2 for ch in value[1:])
-        elif len(value) == 7:
-            pass
         elif len(value) == 9:
             raise ValueError(
                 f"8-digit hex (RGBA) not supported for contrast calculation: '{value}'. "
                 "Use 6-digit hex (RGB) only."
             )
-        else:
+        elif len(value) != 7:
             raise ValueError(f"Unsupported hex color '{value}'")
         try:
             int(value[1:], 16)

--- a/semantic_substrate/renderer/contrast_validator.py
+++ b/semantic_substrate/renderer/contrast_validator.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python3
+from __future__ import annotations
+
+from src.renderers.theme_runtime import SemanticThemeRuntime
 
 class ContrastValidator:
     """
@@ -6,22 +8,36 @@ class ContrastValidator:
     Enforces semantic theme safety constraints for the ABACUS_RENDER_PIPELINE.
     """
 
-    def __init__(self):
+    MIN_AA_RATIO = 4.5
+
+    def __init__(self) -> None:
+        warning_dark = SemanticThemeRuntime().resolve("warning", "dark")
         self.target_invariants = {
             "warning": {
                 "dark": {
-                    "background": "#4A3110",
-                    "text": "#FFE9A3",
+                    "background": warning_dark.background,
+                    "text": warning_dark.text,
                 }
             }
         }
-        self.MIN_AA_RATIO = 4.5
+
+    def _normalize_hex(self, value: str) -> str:
+        if not value.startswith("#"):
+            raise ValueError(f"Unsupported hex color '{value}'")
+        if len(value) == 4:
+            return "#" + "".join(ch * 2 for ch in value[1:])
+        if len(value) == 7:
+            return value
+        if len(value) == 9:
+            raise ValueError(
+                f"8-digit hex (RGBA) not supported for contrast calculation: '{value}'. "
+                "Use 6-digit hex (RGB) only."
+            )
+        raise ValueError(f"Unsupported hex color '{value}'")
 
     def _hex_to_srgb(self, hex_str: str) -> tuple[float, float, float]:
         """Converts hex color values to normalized sRGB components."""
-        value = hex_str.lstrip("#")
-        if len(value) != 6:
-            raise ValueError(f"Invalid Hex format detected: {hex_str}")
+        value = self._normalize_hex(hex_str)[1:]
         return tuple(int(value[i : i + 2], 16) / 255.0 for i in (0, 2, 4))
 
     def calculate_relative_luminance(self, hex_color: str) -> float:
@@ -53,7 +69,8 @@ class ContrastValidator:
         ratio = self.calculate_contrast_ratio(background_hex, text_hex)
         is_compliant = ratio >= self.MIN_AA_RATIO
         return {
-            "contrast_ratio": round(ratio, 2),
+            "contrast_ratio": ratio,
+            "contrast_ratio_rounded": round(ratio, 2),
             "wcag_aa_compliant": is_compliant,
             "action_required": not is_compliant,
         }

--- a/semantic_substrate/renderer/contrast_validator.py
+++ b/semantic_substrate/renderer/contrast_validator.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+class ContrastValidator:
+    """
+    G5 Hardened WCAG 2.1 Luminance and Relative Contrast Ratio Validation Engine.
+    Enforces semantic theme safety constraints for the ABACUS_RENDER_PIPELINE.
+    """
+
+    def __init__(self):
+        self.target_invariants = {
+            "warning": {
+                "dark": {
+                    "background": "#4A3110",
+                    "text": "#FFE9A3",
+                }
+            }
+        }
+        self.MIN_AA_RATIO = 4.5
+
+    def _hex_to_srgb(self, hex_str: str) -> tuple[float, float, float]:
+        """Converts hex color values to normalized sRGB components."""
+        value = hex_str.lstrip("#")
+        if len(value) != 6:
+            raise ValueError(f"Invalid Hex format detected: {hex_str}")
+        return tuple(int(value[i : i + 2], 16) / 255.0 for i in (0, 2, 4))
+
+    def calculate_relative_luminance(self, hex_color: str) -> float:
+        """Calculates relative luminance using the WCAG formula."""
+        r, g, b = self._hex_to_srgb(hex_color)
+        components = []
+        for channel in (r, g, b):
+            if channel <= 0.03928:
+                components.append(channel / 12.92)
+            else:
+                components.append(((channel + 0.055) / 1.055) ** 2.4)
+
+        return (
+            0.2126 * components[0]
+            + 0.7152 * components[1]
+            + 0.0722 * components[2]
+        )
+
+    def calculate_contrast_ratio(self, color1_hex: str, color2_hex: str) -> float:
+        """Computes contrast ratio between two colors."""
+        l1 = self.calculate_relative_luminance(color1_hex)
+        l2 = self.calculate_relative_luminance(color2_hex)
+        lightest = max(l1, l2)
+        darkest = min(l1, l2)
+        return (lightest + 0.05) / (darkest + 0.05)
+
+    def validate_theme_node(self, background_hex: str, text_hex: str) -> dict:
+        """Validates a text/background pair against WCAG AA."""
+        ratio = self.calculate_contrast_ratio(background_hex, text_hex)
+        is_compliant = ratio >= self.MIN_AA_RATIO
+        return {
+            "contrast_ratio": round(ratio, 2),
+            "wcag_aa_compliant": is_compliant,
+            "action_required": not is_compliant,
+        }

--- a/semantic_substrate/renderer/contrast_validator.py
+++ b/semantic_substrate/renderer/contrast_validator.py
@@ -13,9 +13,21 @@ def _load_warning_dark_invariant() -> dict[str, str]:
     with theme_path.open("r", encoding="utf-8") as handle:
         data = yaml.safe_load(handle)
     if not isinstance(data, dict):
-        raise ValueError(f"Invalid YAML structure in {theme_path}")
+        raise ValueError(
+            f"Invalid YAML in {theme_path}: expected root mapping/dictionary."
+        )
     semantic_cards = data.get("semantic_cards", {})
-    warning_dark = semantic_cards.get("warning", {}).get("dark", {})
+    warning = semantic_cards.get("warning", {})
+    warning_dark = warning.get("dark", {})
+    if not isinstance(warning_dark, dict):
+        raise ValueError(
+            f"Invalid warning.dark mapping in {theme_path}: expected dictionary."
+        )
+    if "background" not in warning_dark or "text" not in warning_dark:
+        raise ValueError(
+            f"Missing required warning.dark colors in {theme_path}: "
+            "expected 'background' and 'text'."
+        )
     return {
         "background": warning_dark["background"],
         "text": warning_dark["text"],
@@ -44,15 +56,21 @@ class ContrastValidator:
         if not value.startswith("#"):
             raise ValueError(f"Unsupported hex color '{value}'")
         if len(value) == 4:
-            return "#" + "".join(ch * 2 for ch in value[1:])
-        if len(value) == 7:
-            return value
-        if len(value) == 9:
+            value = "#" + "".join(ch * 2 for ch in value[1:])
+        elif len(value) == 7:
+            pass
+        elif len(value) == 9:
             raise ValueError(
                 f"8-digit hex (RGBA) not supported for contrast calculation: '{value}'. "
                 "Use 6-digit hex (RGB) only."
             )
-        raise ValueError(f"Unsupported hex color '{value}'")
+        else:
+            raise ValueError(f"Unsupported hex color '{value}'")
+        try:
+            int(value[1:], 16)
+        except ValueError as exc:
+            raise ValueError(f"Unsupported hex color '{value}'") from exc
+        return value
 
     def _hex_to_srgb(self, hex_str: str) -> tuple[float, float, float]:
         """Converts hex color values to normalized sRGB components."""

--- a/semantic_substrate/renderer/contrast_validator.py
+++ b/semantic_substrate/renderer/contrast_validator.py
@@ -1,6 +1,25 @@
 from __future__ import annotations
 
-from src.renderers.theme_runtime import SemanticThemeRuntime
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+
+@lru_cache(maxsize=1)
+def _load_warning_dark_invariant() -> dict[str, str]:
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    theme_path = repo_root / "themes" / "semantic_cards.yaml"
+    with theme_path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid YAML structure in {theme_path}")
+    semantic_cards = data.get("semantic_cards", {})
+    warning_dark = semantic_cards.get("warning", {}).get("dark", {})
+    return {
+        "background": warning_dark["background"],
+        "text": warning_dark["text"],
+    }
 
 class ContrastValidator:
     """
@@ -11,12 +30,12 @@ class ContrastValidator:
     MIN_AA_RATIO = 4.5
 
     def __init__(self) -> None:
-        warning_dark = SemanticThemeRuntime().resolve("warning", "dark")
+        warning_dark = _load_warning_dark_invariant()
         self.target_invariants = {
             "warning": {
                 "dark": {
-                    "background": warning_dark.background,
-                    "text": warning_dark.text,
+                    "background": warning_dark["background"],
+                    "text": warning_dark["text"],
                 }
             }
         }

--- a/tests/renderer/test_contrast_validator.py
+++ b/tests/renderer/test_contrast_validator.py
@@ -1,19 +1,23 @@
+from pathlib import Path
+
 import pytest
+import yaml
 
 from semantic_substrate.renderer.contrast_validator import ContrastValidator
-from src.renderers.theme_runtime import SemanticThemeRuntime
 
 
 def test_target_invariant_warning_card_contrast():
     validator = ContrastValidator()
-    warning_dark_theme = SemanticThemeRuntime().resolve("warning", "dark")
+    theme_path = Path(__file__).resolve().parent.parent.parent / "themes" / "semantic_cards.yaml"
+    with theme_path.open("r", encoding="utf-8") as handle:
+        warning_dark_theme = yaml.safe_load(handle)["semantic_cards"]["warning"]["dark"]
     dark_warning = validator.target_invariants["warning"]["dark"]
 
-    assert dark_warning["background"] == warning_dark_theme.background
-    assert dark_warning["text"] == warning_dark_theme.text
+    assert dark_warning["background"] == warning_dark_theme["background"]
+    assert dark_warning["text"] == warning_dark_theme["text"]
 
     metrics = validator.validate_theme_node(
-        warning_dark_theme.background, warning_dark_theme.text
+        warning_dark_theme["background"], warning_dark_theme["text"]
     )
     assert metrics["wcag_aa_compliant"] is True
     assert metrics["contrast_ratio"] >= validator.MIN_AA_RATIO

--- a/tests/renderer/test_contrast_validator.py
+++ b/tests/renderer/test_contrast_validator.py
@@ -1,22 +1,39 @@
-#!/usr/bin/env python3
+import pytest
 
 from semantic_substrate.renderer.contrast_validator import ContrastValidator
+from src.renderers.theme_runtime import SemanticThemeRuntime
 
 
 def test_target_invariant_warning_card_contrast():
     validator = ContrastValidator()
+    warning_dark_theme = SemanticThemeRuntime().resolve("warning", "dark")
     dark_warning = validator.target_invariants["warning"]["dark"]
 
-    bg = dark_warning["background"]
-    text = dark_warning["text"]
+    assert dark_warning["background"] == warning_dark_theme.background
+    assert dark_warning["text"] == warning_dark_theme.text
 
-    metrics = validator.validate_theme_node(bg, text)
-
-    assert metrics["contrast_ratio"] >= 4.5
+    metrics = validator.validate_theme_node(
+        warning_dark_theme.background, warning_dark_theme.text
+    )
     assert metrics["wcag_aa_compliant"] is True
+    assert metrics["contrast_ratio"] >= validator.MIN_AA_RATIO
 
 
 def test_failing_contrast_combination():
     validator = ContrastValidator()
     metrics = validator.validate_theme_node("#FFFFFF", "#D3D3D3")
+
     assert metrics["wcag_aa_compliant"] is False
+    assert metrics["action_required"] is True
+
+
+def test_hex_normalization_and_rejections():
+    validator = ContrastValidator()
+
+    assert validator.calculate_relative_luminance("#abc") == pytest.approx(
+        validator.calculate_relative_luminance("#aabbcc")
+    )
+
+    for invalid_hex in ("##FFFFFF", "FFFFFF", "#FFFFFFFF"):
+        with pytest.raises(ValueError):
+            validator.calculate_relative_luminance(invalid_hex)

--- a/tests/renderer/test_contrast_validator.py
+++ b/tests/renderer/test_contrast_validator.py
@@ -38,6 +38,12 @@ def test_hex_normalization_and_rejections():
         validator.calculate_relative_luminance("#aabbcc")
     )
 
-    for invalid_hex in ("##FFFFFF", "FFFFFF", "#FFFFFFFF", "#xyz"):
-        with pytest.raises(ValueError):
+    expected = {
+        "##FFFFFF": "Unsupported hex color",
+        "FFFFFF": "Unsupported hex color",
+        "#FFFFFFFF": r"8-digit hex \(RGBA\) not supported",
+        "#xyz": "Unsupported hex color",
+    }
+    for invalid_hex, message in expected.items():
+        with pytest.raises(ValueError, match=message):
             validator.calculate_relative_luminance(invalid_hex)

--- a/tests/renderer/test_contrast_validator.py
+++ b/tests/renderer/test_contrast_validator.py
@@ -38,6 +38,6 @@ def test_hex_normalization_and_rejections():
         validator.calculate_relative_luminance("#aabbcc")
     )
 
-    for invalid_hex in ("##FFFFFF", "FFFFFF", "#FFFFFFFF"):
+    for invalid_hex in ("##FFFFFF", "FFFFFF", "#FFFFFFFF", "#xyz"):
         with pytest.raises(ValueError):
             validator.calculate_relative_luminance(invalid_hex)

--- a/tests/renderer/test_contrast_validator.py
+++ b/tests/renderer/test_contrast_validator.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+from semantic_substrate.renderer.contrast_validator import ContrastValidator
+
+
+def test_target_invariant_warning_card_contrast():
+    validator = ContrastValidator()
+    dark_warning = validator.target_invariants["warning"]["dark"]
+
+    bg = dark_warning["background"]
+    text = dark_warning["text"]
+
+    metrics = validator.validate_theme_node(bg, text)
+
+    assert metrics["contrast_ratio"] >= 4.5
+    assert metrics["wcag_aa_compliant"] is True
+
+
+def test_failing_contrast_combination():
+    validator = ContrastValidator()
+    metrics = validator.validate_theme_node("#FFFFFF", "#D3D3D3")
+    assert metrics["wcag_aa_compliant"] is False


### PR DESCRIPTION
### Motivation
- Provide a localized WCAG 2.1 contrast validator to harden the ABACUS_RENDER_PIPELINE theming invariants for Phase A6.
- Ensure semantic theme safety by validating relative luminance and contrast ratios against an AA threshold.
- Ship a lightweight validator and tests so the pipeline can validate target invariants without depending on remote connectors.

### Description
- Add `ContrastValidator` at `semantic_substrate/renderer/contrast_validator.py` implementing hex parsing, sRGB conversion, WCAG relative luminance, contrast-ratio calculation, and an AA compliance check with `MIN_AA_RATIO = 4.5`.
- Include a built-in `target_invariants` entry for the `warning.dark` theme pair (`#4A3110` background, `#FFE9A3` text) used for invariant validation.
- Add unit tests in `tests/renderer/test_contrast_validator.py` that assert the target invariant passes and that a low-contrast pair (`#FFFFFF` on `#D3D3D3`) fails.

### Testing
- Ran `pytest tests/renderer/test_contrast_validator.py -v` which executed the test suite for the new validator.
- Test results: `2 passed` and the suite completed successfully. 
- No additional automated test failures were observed for the added files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a131fbecbbc832e933768c36417368b)