### PR TITLE
feat(incubator): add chat tuple ingress mapping scaffold

### DIFF
--- a/docs/incubator_index.md
+++ b/docs/incubator_index.md
@@ -1,0 +1,5 @@
+# Incubator Index
+
+| id | date | category | theme | status |
+|---|---|---|---|---|
+| 26_W22_12_35__INCUBATOR__RUNTIME_GOVERNANCE__CHAT_TUPLE_INGRESS_MAPPING__W000 | 2026-05-26 | INCUBATOR | RUNTIME_GOVERNANCE | active |

--- a/docs/incubator_runtime_map.md
+++ b/docs/incubator_runtime_map.md
@@ -1,0 +1,9 @@
+# Incubator Runtime Map
+
+This document defines the W000/W001 ingest flow:
+
+1. Create tuple files in `incubator/` using the naming convention.
+2. Parse tuple files locally with `scripts/parse_chat_tuple.py`.
+3. Generate `docs/incubator_index.md` using `scripts/build_incubator_index.py`.
+
+The current scope intentionally excludes DMAIC and advanced extraction until W002+.

--- a/incubator/26_W22_12_35__INCUBATOR__RUNTIME_GOVERNANCE__CHAT_TUPLE_INGRESS_MAPPING__W000.yml
+++ b/incubator/26_W22_12_35__INCUBATOR__RUNTIME_GOVERNANCE__CHAT_TUPLE_INGRESS_MAPPING__W000.yml
@@ -1,0 +1,24 @@
+id: "26_W22_12_35__INCUBATOR__RUNTIME_GOVERNANCE__CHAT_TUPLE_INGRESS_MAPPING__W000"
+date: "2026-05-26"
+time_local: "12:35"
+iso_week: "2026-W22"
+category: "INCUBATOR"
+theme: "RUNTIME_GOVERNANCE"
+title: "CHAT_TUPLE_INGRESS_MAPPING"
+wave: "W000"
+status: "active"
+repo: "GBOGEB/PROGRAM-COOL"
+branch: "wave/W000-incubator-chat-tuple-ingress"
+source_type: "chat_tuple"
+tuple:
+  actor: "codex"
+  prompt: "Initialize incubator tuple ingestion scaffold with naming convention and index builder."
+  outcome: "Scaffold created for W000/W001 with tuple parser and markdown index generator."
+  tags:
+    - incubator
+    - tuple
+    - governance
+  artifacts:
+    - incubator/session_tuple_schema.yml
+    - scripts/parse_chat_tuple.py
+    - scripts/build_incubator_index.py

--- a/incubator/README.md
+++ b/incubator/README.md
@@ -1,0 +1,18 @@
+# INCUBATOR Layer (W000/W001)
+
+This directory stores machine-readable chat/session tuple source files.
+
+## Naming convention
+
+`YY_Www_HH_MM__CATEGORY__THEME__TITLE__STATUS`
+
+Example:
+
+`26_W22_12_35__INCUBATOR__RUNTIME_GOVERNANCE__CHAT_TUPLE_INGRESS_MAPPING__W000`
+
+## Wave scope
+
+- **W000**: naming convention + tuple schema
+- **W001**: local parser + Markdown index generation
+
+Future waves (W002+) will add DMAIC tracking, extraction, linkage, and routing.

--- a/incubator/session_tuple_schema.yml
+++ b/incubator/session_tuple_schema.yml
@@ -1,0 +1,62 @@
+$schema: "https://yaml.org/spec/1.2/spec.html"
+schema_id: "session_tuple.v1"
+description: "Schema contract for incubator chat/session tuple ingestion files."
+required:
+  - id
+  - date
+  - time_local
+  - iso_week
+  - category
+  - theme
+  - title
+  - wave
+  - status
+  - repo
+  - branch
+  - source_type
+  - tuple
+fields:
+  id:
+    type: string
+    pattern: "YY_Www_HH_MM__CATEGORY__THEME__TITLE__STATUS"
+  date:
+    type: string
+    format: date
+  time_local:
+    type: string
+    format: HH:MM
+  iso_week:
+    type: string
+    format: YYYY-Www
+  category:
+    type: string
+  theme:
+    type: string
+  title:
+    type: string
+  wave:
+    type: string
+  status:
+    type: string
+    enum: [active, paused, archived]
+  repo:
+    type: string
+  branch:
+    type: string
+  source_type:
+    type: string
+    enum: [chat_tuple, session_tuple]
+  tuple:
+    type: object
+    required: [actor, prompt, outcome]
+    fields:
+      actor:
+        type: string
+      prompt:
+        type: string
+      outcome:
+        type: string
+      tags:
+        type: list[string]
+      artifacts:
+        type: list[string]

--- a/maps/category_map.yml
+++ b/maps/category_map.yml
@@ -1,0 +1,5 @@
+version: 1
+categories:
+  INCUBATOR:
+    description: "Early-stage machine-readable runtime artifacts."
+    owner: "runtime-governance"

--- a/maps/repo_ingress_map.yml
+++ b/maps/repo_ingress_map.yml
@@ -1,0 +1,8 @@
+version: 1
+ingress:
+  chat_tuple:
+    source_dir: "incubator"
+    parser: "scripts/parse_chat_tuple.py"
+    index_builder: "scripts/build_incubator_index.py"
+    output_docs:
+      - "docs/incubator_index.md"

--- a/maps/theme_map.yml
+++ b/maps/theme_map.yml
@@ -1,0 +1,5 @@
+version: 1
+themes:
+  RUNTIME_GOVERNANCE:
+    keywords: [runtime, governance, lineage, policy, orchestration]
+    description: "Runtime policy, controls, and execution governance themes."

--- a/scripts/build_incubator_index.py
+++ b/scripts/build_incubator_index.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Build markdown index for incubator tuple files."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    parser = root / "scripts" / "parse_chat_tuple.py"
+    result = subprocess.check_output(["python3", str(parser), str(root / "incubator")], text=True)
+
+    import json
+
+    items = json.loads(result)
+    out = ["# Incubator Index", "", "| id | date | category | theme | status |", "|---|---|---|---|---|"]
+    for item in items:
+        out.append(
+            f"| {item.get('id','')} | {item.get('date','')} | {item.get('category','')} | {item.get('theme','')} | {item.get('status','')} |"
+        )
+
+    output = root / "docs" / "incubator_index.md"
+    output.write_text("\n".join(out) + "\n", encoding="utf-8")
+    print(f"Wrote {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/parse_chat_tuple.py
+++ b/scripts/parse_chat_tuple.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Parse incubator tuple YAML files using safe local parsing only."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_simple_yaml(text: str) -> dict:
+    """Parse a conservative YAML subset (key/value + one-level nested maps/lists)."""
+    root: dict = {}
+    stack = [(0, root)]
+
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+
+        indent = len(line) - len(line.lstrip(" "))
+        line = line.strip()
+
+        while stack and indent < stack[-1][0]:
+            stack.pop()
+
+        container = stack[-1][1]
+
+        if line.startswith("- "):
+            value = line[2:].strip().strip('"')
+            if isinstance(container, list):
+                container.append(value)
+            continue
+
+        if ":" not in line:
+            continue
+
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+
+        if value == "":
+            next_container = {}
+            container[key] = next_container
+            stack.append((indent + 2, next_container))
+        elif value == "[]":
+            container[key] = []
+        else:
+            cleaned = value.strip('"')
+            container[key] = cleaned
+            if cleaned == "-":
+                container[key] = []
+
+        if key in container and isinstance(container[key], list):
+            stack.append((indent + 2, container[key]))
+
+    return root
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", nargs="?", default="incubator")
+    args = parser.parse_args()
+
+    base = Path(args.path)
+    tuples = []
+
+    for file in sorted(base.glob("*.yml")):
+        data = parse_simple_yaml(file.read_text(encoding="utf-8"))
+        if data.get("id"):
+            tuples.append(data)
+
+    print(json.dumps(tuples, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Introduce an INCUBATOR layer to capture chat/session tuples as machine-readable source artifacts for later indexing and static rendering. 
- Establish a canonical naming convention and minimal schema to make tuple files discoverable and consistent. 
- Provide a small, reviewable W000/W001 wave that enables local parsing and Markdown index generation without external dependencies. 

### Description
- Add a YAML schema at `incubator/session_tuple_schema.yml` and a seeded tuple file `incubator/26_W22_12_35__INCUBATOR__RUNTIME_GOVERNANCE__CHAT_TUPLE_INGRESS_MAPPING__W000.yml` following the naming pattern. 
- Add mapping files `maps/category_map.yml`, `maps/theme_map.yml`, and `maps/repo_ingress_map.yml` to describe category/theme keywords and ingress configuration. 
- Implement a conservative, stdlib-only YAML subset parser in `scripts/parse_chat_tuple.py` and a Markdown index builder `scripts/build_incubator_index.py` that invokes the parser and writes `docs/incubator_index.md`. 
- Add documentation and workflow notes in `incubator/README.md` and `docs/incubator_runtime_map.md`. 

### Testing
- Ran `python3 scripts/build_incubator_index.py` which executed the parser and wrote `docs/incubator_index.md` successfully. 
- Ran `python3 scripts/parse_chat_tuple.py incubator` which printed the seeded tuple JSON successfully. 
- Ran `python3 -m py_compile scripts/parse_chat_tuple.py scripts/build_incubator_index.py` and both scripts compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1578effbb4832e88abe2d4e6945481)