### PR TITLE
W000 bootstrap: federated semantic trace scaffolding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "ARTSTYLE-WIP W000 Federation Bootstrap",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "postCreateCommand": "pip install -r requirements.txt",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "files.insertFinalNewline": true
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-toolsai.jupyter",
+        "yzhang.markdown-all-in-one"
+      ]
+    }
+  }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,50 @@
-# Pull Request
+# [WAVE]
 
-## Summary
-Describe the governance or delivery change.
+## Semantic Scope
+- [ ] Governance
+- [ ] Federation
+- [ ] Runtime
+- [ ] Telemetry
+- [ ] Render
+- [ ] Drift
 
-## Validation
-- [ ] Repository review completed
-- [ ] No secrets committed
-- [ ] Existing execution preserved
+---
 
-## Review objectives
-Describe what reviewers should focus on.
+# Tuple Metadata
 
-## Lineage
-Program: <program>
-Repository: CODEX
+| Key | Value |
+|---|---|
+| Wave | W000 |
+| Trace | FEDERATION.RUNTIME |
+| State | ACTIVE |
+| Renderable | YES |
+| Drift Stable | YES |
+
+---
+
+# Completion Vector
+
+| Domain | Completion |
+|---|---|
+| Structure | 90% |
+| Federation | 40% |
+| Telemetry | 35% |
+| Renderability | 75% |
+
+---
+
+# Near-Miss Optimizations
+
+-
+-
+-
+
+---
+
+# Render Validation
+
+- [ ] Markdown
+- [ ] YAML
+- [ ] HTML
+- [ ] GitHub Pages
+- [ ] Telemetry

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+
+## W000-FEDERATED-SEMANTIC-TRACE
+
+This repository now includes a Wave W000 bootstrap for a dual-render federation model connecting ABACUS, CODEX, and MCP runtime orchestration.
+
+- Human semantic layer for topic-first readability
+- Machine sequential layer for temporal orchestration and telemetry
+- Federated traceability with semantic prefix indexing
+- Completion-vector scaffolding and drift monitoring bootstrap
+
+See:
+- `federation/semantic_index/schema.yaml`
+- `telemetry/pca/drift_monitor.py`
+- `agents/codex/MCP_INSTRUCTION.md`
+- `agents/abacus/FEDERATION_PROTOCOL.md`
+
 # 🌌 G9 Unified Federation Framework & System Verification Specification
 
 ## 🛡️ Level 8 (L8) Closed-Loop Post-Commissioning Summary

--- a/agents/abacus/FEDERATION_PROTOCOL.md
+++ b/agents/abacus/FEDERATION_PROTOCOL.md
@@ -1,0 +1,26 @@
+# ABACUS ↔ CODEX Federation Protocol (W000)
+
+## Core Contract
+- Preserve semantic traceability.
+- Preserve machine-sequential chronology.
+- Maintain dual-render synchronization.
+- Emit structured metadata for every orchestration action.
+
+## Required Prefixes
+- [TOPIC]
+- [TRACE]
+- [WAVE]
+- [STATE]
+- [DRIFT]
+- [NEARMISS]
+- [RENDER]
+- [FEDERATION]
+- [DMAIC]
+- [SSOT]
+
+## Tuple Lineage Format
+Use:
+`[SEMANTIC].[TRACE].[TEMPORAL].[WAVE]`
+
+Example:
+`GOVERNANCE.RUNTIME.2622_1535.W000`

--- a/agents/codex/MCP_INSTRUCTION.md
+++ b/agents/codex/MCP_INSTRUCTION.md
@@ -1,0 +1,34 @@
+[FEDERATION.RUNTIME.W000]
+
+You are operating as a federated orchestration agent inside the ARTSTYLE runtime.
+
+Core principle:
+IF IT CANNOT RENDER, IT CANNOT GOVERN.
+
+Primary objectives:
+1. Preserve semantic traceability.
+2. Preserve machine-sequential chronology.
+3. Never destroy tuple lineage.
+4. Always emit structured metadata.
+5. Detect drift between semantic and temporal layers.
+6. Promote reusable orchestration primitives.
+
+Required output blocks:
+- [TOPIC]
+- [TRACE]
+- [STATE]
+- [WAVE]
+- [DRIFT]
+- [RENDER]
+- [NEARMISS]
+
+When proposing changes:
+- emit concise commit messages
+- emit orchestration impact summary
+- emit federation impact score
+- emit semantic lineage references
+
+Never flatten semantic abstractions into pure chronological logs.
+Maintain dual-render synchronization between:
+- human semantic layer
+- machine temporal layer

--- a/federation/semantic_index/schema.yaml
+++ b/federation/semantic_index/schema.yaml
@@ -1,0 +1,55 @@
+version: 1
+schema: FEDERATED_SEMANTIC_TRACE
+
+semantic_prefixes:
+  - "[TOPIC]"
+  - "[TRACE]"
+  - "[WAVE]"
+  - "[STATE]"
+  - "[DRIFT]"
+  - "[NEARMISS]"
+  - "[RENDER]"
+  - "[FEDERATION]"
+  - "[DMAIC]"
+  - "[SSOT]"
+
+session_tuple:
+  semantic:
+    topic: "GOVERNANCE.RUNTIME.ORCHESTRATION"
+    theme: "ABACUS_CODEX_FEDERATION"
+    intent: "Semantic tracing bridge for recursive orchestration"
+    status: "ACTIVE"
+    wave: "W000"
+    trace: "FEDERATION.WIRELINK.RUNTIME"
+    related:
+      - ARTSTYLE
+      - MCP
+      - DMAIC
+      - PCA
+      - RENDER_GOVERNANCE
+  machine:
+    stamp: "2622_1535"
+    wave: "W000"
+    tuple_id: "FEDERATION.RUNTIME.WIRELINK"
+    temporal_index: 2026.22.1535
+    orchestration:
+      source: CHATGPT
+      federation:
+        - ABACUS
+        - CODEX
+        - MCP
+    semantic_hash:
+      primary: governance
+      secondary: runtime
+      tertiary: federation
+    drift_tracking:
+      enabled: true
+      pca_monitor: true
+
+completion_vector:
+  structure: 0.90
+  renderability: 0.75
+  federation: 0.40
+  semantic_traceability: 0.85
+  orchestration_readiness: 0.30
+  drift_stability: 0.55

--- a/telemetry/pca/drift_monitor.py
+++ b/telemetry/pca/drift_monitor.py
@@ -1,0 +1,45 @@
+"""W000 federated semantic drift monitor.
+
+Tracks drift between semantic and sequential layers and emits a lightweight
+telemetry payload for orchestration gating.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+
+
+@dataclass(frozen=True)
+class DriftSnapshot:
+    semantic_alignment: float
+    temporal_alignment: float
+    drift_score: float
+    pca_monitor: bool = True
+
+
+def compute_drift(semantic_alignment: float, temporal_alignment: float) -> DriftSnapshot:
+    """Return a bounded drift snapshot.
+
+    Drift score is absolute deviation between semantic and temporal alignment.
+    """
+    semantic = max(0.0, min(1.0, semantic_alignment))
+    temporal = max(0.0, min(1.0, temporal_alignment))
+    score = abs(semantic - temporal)
+    return DriftSnapshot(
+        semantic_alignment=semantic,
+        temporal_alignment=temporal,
+        drift_score=round(score, 4),
+    )
+
+
+def render_snapshot(snapshot: DriftSnapshot) -> dict:
+    """Render snapshot as serializable telemetry."""
+    payload = asdict(snapshot)
+    payload["state"] = "STABLE" if snapshot.drift_score <= 0.2 else "DRIFTING"
+    payload["trace"] = "FEDERATION.RUNTIME.W000"
+    return payload
+
+
+if __name__ == "__main__":
+    sample = compute_drift(semantic_alignment=0.85, temporal_alignment=0.55)
+    print(render_snapshot(sample))


### PR DESCRIPTION
### Motivation
- Provide a Wave `W000` bootstrap to enable a dual-render federation model that preserves human-first semantic labeling while supporting machine-sequential telemetry and federated orchestration.
- Introduce a minimal semantic prefix/indexing system and completion-vector scaffolding to improve grep discoverability, LLM retrieval anchors, and PR lineage for orchestration workflows.
- Add a lightweight drift-monitoring entrypoint to detect divergence between semantic and temporal layers and to seed telemetry gating for later waves.

### Description
- Added a devcontainer configuration at `.devcontainer/devcontainer.json` to standardize local/runtime environment setup for the ARTSTYLE W000 bootstrap.
- Introduced the federated semantic schema at `federation/semantic_index/schema.yaml` that defines the `session_tuple` (semantic + machine layers), `semantic_prefixes`, and a `completion_vector` for readiness scoring.
- Implemented a PCA-style drift monitor `telemetry/pca/drift_monitor.py` with `compute_drift` and `render_snapshot` utilities that produce a serializable telemetry payload and a `STABLE`/`DRIFTING` state.
- Added operator docs for agent contracts: `agents/codex/MCP_INSTRUCTION.md` (CODEX MCP instructions) and `agents/abacus/FEDERATION_PROTOCOL.md` (ABACUS↔CODEX protocol and lineage format), plus a repository PR template at `.github/pull_request_template.md` and a README anchor section for W000.
- Added a runtime scaffolding placeholder at `runtime/incubator/.gitkeep` to reserve the incubator path for future waves.

### Testing
- Ran the drift monitor with `python telemetry/pca/drift_monitor.py`, which executed and printed a sample telemetry payload (e.g. returned `state: "DRIFTING"` for the sample inputs), indicating the module runs successfully.
- No additional automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a15b52b6778832e9634019a29755359)