### PR TITLE
ALaT Clarification Bridge: add SSOT, validator, generator, templates, and CI workflow

### DIFF
--- a/.github/workflows/build-clarification-bridge.yml
+++ b/.github/workflows/build-clarification-bridge.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Run bridge tests
         run: |
+          test -f tests/test_alat_clarification_bridge.py
           pytest tests/test_alat_clarification_bridge.py
 
       - name: Upload bridge artifacts

--- a/.github/workflows/build-clarification-bridge.yml
+++ b/.github/workflows/build-clarification-bridge.yml
@@ -1,0 +1,49 @@
+name: Build ALaT Clarification Bridge
+
+on:
+  pull_request:
+    paths:
+      - 'rtm_integration/contract_followup/alat_clarification_bridge/**'
+      - '.github/workflows/build-clarification-bridge.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'rtm_integration/contract_followup/alat_clarification_bridge/**'
+      - '.github/workflows/build-clarification-bridge.yml'
+
+jobs:
+  build-clarification-bridge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install PyYAML openpyxl
+
+      - name: Validate SSOT
+        run: |
+          python rtm_integration/contract_followup/alat_clarification_bridge/tools/validate_ssot.py
+
+      - name: Generate bridge artifacts
+        run: |
+          python rtm_integration/contract_followup/alat_clarification_bridge/tools/generate_bridge.py
+          test -f rtm_integration/contract_followup/alat_clarification_bridge/build/bidder_response.md
+          test -f rtm_integration/contract_followup/alat_clarification_bridge/build/bidder_response.html
+
+      - name: Upload bridge artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: alat-clarification-bridge
+          path: |
+            rtm_integration/contract_followup/alat_clarification_bridge/build/bidder_response.md
+            rtm_integration/contract_followup/alat_clarification_bridge/build/bidder_response.html
+            rtm_integration/contract_followup/alat_clarification_bridge/build/review_checklist.md
+            rtm_integration/contract_followup/alat_clarification_bridge/build/alat_clarification_bridge.xlsx
+          if-no-files-found: ignore

--- a/.github/workflows/build-clarification-bridge.yml
+++ b/.github/workflows/build-clarification-bridge.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - 'rtm_integration/contract_followup/alat_clarification_bridge/**'
+      - 'tests/test_alat_clarification_bridge.py'
       - '.github/workflows/build-clarification-bridge.yml'
   push:
     branches:
       - main
     paths:
       - 'rtm_integration/contract_followup/alat_clarification_bridge/**'
+      - 'tests/test_alat_clarification_bridge.py'
       - '.github/workflows/build-clarification-bridge.yml'
 
 jobs:
@@ -25,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install PyYAML openpyxl
+          pip install PyYAML openpyxl pytest
 
       - name: Validate SSOT
         run: |
@@ -36,6 +38,14 @@ jobs:
           python rtm_integration/contract_followup/alat_clarification_bridge/tools/generate_bridge.py
           test -f rtm_integration/contract_followup/alat_clarification_bridge/build/bidder_response.md
           test -f rtm_integration/contract_followup/alat_clarification_bridge/build/bidder_response.html
+          test -f rtm_integration/contract_followup/alat_clarification_bridge/build/review_checklist.md
+          test -f rtm_integration/contract_followup/alat_clarification_bridge/build/stakeholder_review.md
+          test -f rtm_integration/contract_followup/alat_clarification_bridge/build/management_summary.md
+          test -f rtm_integration/contract_followup/alat_clarification_bridge/build/alat_clarification_bridge.xlsx
+
+      - name: Run bridge tests
+        run: |
+          pytest tests/test_alat_clarification_bridge.py
 
       - name: Upload bridge artifacts
         uses: actions/upload-artifact@v4
@@ -45,5 +55,7 @@ jobs:
             rtm_integration/contract_followup/alat_clarification_bridge/build/bidder_response.md
             rtm_integration/contract_followup/alat_clarification_bridge/build/bidder_response.html
             rtm_integration/contract_followup/alat_clarification_bridge/build/review_checklist.md
+            rtm_integration/contract_followup/alat_clarification_bridge/build/stakeholder_review.md
+            rtm_integration/contract_followup/alat_clarification_bridge/build/management_summary.md
             rtm_integration/contract_followup/alat_clarification_bridge/build/alat_clarification_bridge.xlsx
           if-no-files-found: ignore

--- a/rtm_integration/contract_followup/alat_clarification_bridge/OFFER_REGISTER.yaml
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/OFFER_REGISTER.yaml
@@ -1,0 +1,31 @@
+offer_register:
+  - id: OFFER-Q3-RECOVERY-SYSTEM
+    question: Q3
+    title: Recovery system bidder assumptions
+    owner: Contract follow-up lead
+    status: open
+  - id: OFFER-Q3-PURIFICATION-PHILOSOPHY
+    question: Q3
+    title: Purification philosophy roll-up
+    owner: Cryogenic process lead
+    status: open
+  - id: OFFER-Q4-LINE-S-HANDOVER
+    question: Q4
+    title: Line S handover boundary assumptions
+    owner: DBE interface lead
+    status: open
+  - id: OFFER-Q4-WSH-STORAGE-BASIS
+    question: Q4
+    title: WSH storage planning basis
+    owner: Distribution line lead
+    status: open
+  - id: OFFER-Q5-LINE-W-HANDOVER
+    question: Q5
+    title: Line W handover boundary assumptions
+    owner: DBE interface lead
+    status: open
+  - id: OFFER-Q5-DBE-BOUNDARY-ACTION
+    question: Q5
+    title: DBE boundary action tracking
+    owner: DBE interface lead
+    status: open

--- a/rtm_integration/contract_followup/alat_clarification_bridge/README.md
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/README.md
@@ -1,0 +1,23 @@
+# ALaT Clarification Bridge v0.1
+
+YAML-driven single source of truth bridge for RTM traceability, Contract Follow-up, and OFFER_list management across the preserved Q3/Q4/Q5 route.
+
+## Source of truth
+
+- Questions: `ssot/alat_questions_ssot_v0_1.yaml`
+- RTM links: `RTM_LINKS.yaml`
+- OFFER actions: `OFFER_REGISTER.yaml`
+
+## Controls
+
+- Internal sub-question numbers are for SCK traceability only.
+- Bidder-facing answers use short bullet roll-ups.
+- Pressure, temperature, and flow values remain controlled by applicable input/interface tables.
+- Slides are internal preparation material and must not appear in bidder-facing outputs.
+
+## Local checks
+
+```bash
+python rtm_integration/contract_followup/alat_clarification_bridge/tools/validate_ssot.py
+python rtm_integration/contract_followup/alat_clarification_bridge/tools/generate_bridge.py
+```

--- a/rtm_integration/contract_followup/alat_clarification_bridge/RTM_LINKS.yaml
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/RTM_LINKS.yaml
@@ -1,0 +1,25 @@
+rtm_links:
+  RTM-ALAT-Q3-RECOVERY:
+    question: Q3
+    description: Recovery System clarification trace.
+  RTM-ALAT-HE-INVENTORY:
+    question: Q3
+    description: Helium inventory and recovery philosophy trace.
+  RTM-ALAT-Q4-LINE-S:
+    question: Q4
+    description: Line S clarification trace.
+  RTM-ALAT-WSH-STORAGE:
+    question: Q4
+    description: WSH storage planning basis trace.
+  RTM-ALAT-S-HANDOVER-BOUNDARY:
+    question: Q4
+    description: Line S handover boundary trace.
+  RTM-ALAT-Q5-LINE-W:
+    question: Q5
+    description: Line W clarification trace.
+  RTM-ALAT-W-HANDOVER-BOUNDARY:
+    question: Q5
+    description: Line W handover boundary trace.
+  RTM-ALAT-DBE-ACTION:
+    question: Q5
+    description: DBE action trace for W/S nominal, transient, and abnormal handover boundaries.

--- a/rtm_integration/contract_followup/alat_clarification_bridge/docs/review_checklist_merge_gate.md
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/docs/review_checklist_merge_gate.md
@@ -17,6 +17,8 @@ Keep the PR in Draft until all of the following exist and run in CI:
 - [ ] DBE actions exist for W and S nominal, transient, and abnormal handover boundaries.
 - [ ] Generated Markdown artifact exists.
 - [ ] Generated HTML artifact exists.
+- [ ] Generated review checklist Markdown artifact exists.
+- [ ] Generated stakeholder review and management summary artifacts exist from their templates.
 - [ ] Generated Excel artifact exists when `openpyxl` is available.
 
 ## Bidder-facing answer gate
@@ -32,3 +34,8 @@ Keep the PR in Draft until all of the following exist and run in CI:
 - [ ] Confirm every `rtm_links` entry maps to `RTM_LINKS.yaml`.
 - [ ] Confirm every `offer_actions` entry maps to `OFFER_REGISTER.yaml`.
 - [ ] Confirm stakeholder owners accept open actions or update status before merge.
+
+
+## Current PR status
+
+This bridge remains Draft until GitHub CI is green and stakeholder sign-off closes the route preservation, W/S DBE confirmation, and bidder-facing exclusion checks. The placeholders in the generated stakeholder review are intentional review controls, not completed approvals.

--- a/rtm_integration/contract_followup/alat_clarification_bridge/docs/review_checklist_merge_gate.md
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/docs/review_checklist_merge_gate.md
@@ -1,0 +1,34 @@
+# ALaT Clarification Bridge — Review Checklist and Merge Gate
+
+## Draft PR gate
+
+Keep the PR in Draft until all of the following exist and run in CI:
+
+- SSOT validation tool: `tools/validate_ssot.py`
+- Artifact generator: `tools/generate_bridge.py`
+- CI workflow: `.github/workflows/build-clarification-bridge.yml`
+
+## Required validation checks
+
+- [ ] YAML loads successfully.
+- [ ] Exactly Q3, Q4, and Q5 are present.
+- [ ] Each parent question has at least one RTM link.
+- [ ] Each parent question has stakeholder ownership.
+- [ ] DBE actions exist for W and S nominal, transient, and abnormal handover boundaries.
+- [ ] Generated Markdown artifact exists.
+- [ ] Generated HTML artifact exists.
+- [ ] Generated Excel artifact exists when `openpyxl` is available.
+
+## Bidder-facing answer gate
+
+- [ ] Preserve the Q3/Q4/Q5 route.
+- [ ] Use short bullet roll-ups.
+- [ ] Keep internal sub-question numbers for SCK traceability only.
+- [ ] Do not duplicate pressure, temperature, or flow values controlled by input/interface tables.
+- [ ] Do not reference slides or internal preparation slide numbers in bidder-facing outputs.
+
+## RTM and OFFER_list gate
+
+- [ ] Confirm every `rtm_links` entry maps to `RTM_LINKS.yaml`.
+- [ ] Confirm every `offer_actions` entry maps to `OFFER_REGISTER.yaml`.
+- [ ] Confirm stakeholder owners accept open actions or update status before merge.

--- a/rtm_integration/contract_followup/alat_clarification_bridge/docs/review_checklist_merge_gate.md
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/docs/review_checklist_merge_gate.md
@@ -39,3 +39,13 @@ Keep the PR in Draft until all of the following exist and run in CI:
 ## Current PR status
 
 This bridge remains Draft until GitHub CI is green and stakeholder sign-off closes the route preservation, W/S DBE confirmation, and bidder-facing exclusion checks. The placeholders in the generated stakeholder review are intentional review controls, not completed approvals.
+
+## Pre-ready external blockers
+
+The code-level checks are intentionally separate from the final merge decision. Before changing the PR from Draft to Ready:
+
+- [ ] Confirm the GitHub Actions run for `.github/workflows/build-clarification-bridge.yml` is green on the PR branch.
+- [ ] Confirm the CI run produced `alat_clarification_bridge.xlsx` after installing `openpyxl`.
+- [ ] Confirm `tests/test_alat_clarification_bridge.py` is present in the PR file set and was executed by CI.
+- [ ] Close stakeholder sign-offs for route preservation, W/S DBE confirmation, and bidder-facing exclusion.
+- [ ] Post the completed status comment on the live PR if the automation environment could not update GitHub directly.

--- a/rtm_integration/contract_followup/alat_clarification_bridge/ssot/alat_questions_ssot_v0_1.yaml
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/ssot/alat_questions_ssot_v0_1.yaml
@@ -1,0 +1,134 @@
+meta:
+  bridge_id: alat_clarification_bridge
+  version: 0.1
+  status: draft
+  bidder_facing_rules:
+    - Bidder-facing answers use short bullet roll-ups.
+    - Internal sub-question numbers are retained for SCK traceability only.
+    - Pressure, temperature, and flow values are controlled by applicable input/interface tables.
+    - Slides are internal preparation material and must not appear in bidder-facing outputs.
+  controlled_value_policy:
+    pressure_temperature_flow: main_input_and_interface_tables
+    slide_references_allowed_in_bidder_outputs: false
+
+questions:
+  - id: Q3
+    title: Recovery System
+    theme: Recovery system and helium management
+    route: Q3/Q4/Q5
+    decision_posture: Clarify recovery philosophy while preserving interface-table control of design values.
+    stakeholders:
+      discipline_owner: Cryogenic process lead
+      contract_owner: Contract follow-up lead
+      rtm_owner: RTM coordinator
+      dbe_owner: DBE interface lead
+    rtm_links:
+      - RTM-ALAT-Q3-RECOVERY
+      - RTM-ALAT-HE-INVENTORY
+    offer_actions:
+      - OFFER-Q3-RECOVERY-SYSTEM
+      - OFFER-Q3-PURIFICATION-PHILOSOPHY
+    internal_traceability:
+      sub_questions:
+        - Q3.1 recovery system operating philosophy
+        - Q3.2 balloon location basis
+        - Q3.3 purification philosophy
+        - Q3.4 pressure temperature and flow table control
+    bidder_answer:
+      - The recovery system shall be treated as part of the helium management concept and coordinated with the applicable interface tables.
+      - Balloon location remains a layout and interface coordination item; bidders shall identify assumptions and constraints in the offer.
+      - Purification philosophy shall be described by the bidder, including normal operation, regeneration or replacement assumptions, and contamination-control interfaces.
+      - Pressure, temperature, and flow values shall not be restated in the answer and remain governed by the main input/interface tables.
+    controlled_references:
+      pressure_temperature_flow: main input/interface tables
+      bidder_output_exclusions:
+        - slide references
+        - internal preparation slide numbers
+
+  - id: Q4
+    title: Line S
+    theme: Line S handover and storage planning
+    route: Q3/Q4/Q5
+    decision_posture: Clarify Line S boundaries without changing controlled interface values.
+    stakeholders:
+      discipline_owner: Distribution line lead
+      contract_owner: Contract follow-up lead
+      rtm_owner: RTM coordinator
+      dbe_owner: DBE interface lead
+    rtm_links:
+      - RTM-ALAT-Q4-LINE-S
+      - RTM-ALAT-WSH-STORAGE
+      - RTM-ALAT-S-HANDOVER-BOUNDARY
+    offer_actions:
+      - OFFER-Q4-LINE-S-HANDOVER
+      - OFFER-Q4-WSH-STORAGE-BASIS
+    internal_traceability:
+      sub_questions:
+        - Q4.1 Line S nominal handover boundary
+        - Q4.2 Line S transient handover boundary
+        - Q4.3 Line S abnormal handover boundary
+        - Q4.4 WSH storage planning basis
+    bidder_answer:
+      - Line S shall be addressed as an interface-controlled handover route with bidder assumptions clearly identified.
+      - WSH storage planning shall be based on the contract input/interface tables and bidder-defined implementation assumptions.
+      - Nominal, transient, and abnormal operating boundaries shall be coordinated with the DBE interface action before final answer release.
+      - Pressure, temperature, and flow values shall not be restated in the answer and remain governed by the main input/interface tables.
+    dbe_actions:
+      - boundary: Line S nominal handover
+        action: DBE to confirm nominal Line S handover boundary and controlled interface-table references.
+        status: open
+      - boundary: Line S transient handover
+        action: DBE to confirm transient Line S handover boundary and interface response assumptions.
+        status: open
+      - boundary: Line S abnormal handover
+        action: DBE to confirm abnormal Line S handover boundary and fallback interface assumptions.
+        status: open
+    controlled_references:
+      pressure_temperature_flow: main input/interface tables
+      bidder_output_exclusions:
+        - slide references
+        - internal preparation slide numbers
+
+  - id: Q5
+    title: Line W
+    theme: Line W handover and boundary confirmation
+    route: Q3/Q4/Q5
+    decision_posture: Clarify Line W boundaries while preserving RTM and OFFER_list traceability.
+    stakeholders:
+      discipline_owner: Distribution line lead
+      contract_owner: Contract follow-up lead
+      rtm_owner: RTM coordinator
+      dbe_owner: DBE interface lead
+    rtm_links:
+      - RTM-ALAT-Q5-LINE-W
+      - RTM-ALAT-W-HANDOVER-BOUNDARY
+      - RTM-ALAT-DBE-ACTION
+    offer_actions:
+      - OFFER-Q5-LINE-W-HANDOVER
+      - OFFER-Q5-DBE-BOUNDARY-ACTION
+    internal_traceability:
+      sub_questions:
+        - Q5.1 Line W nominal handover boundary
+        - Q5.2 Line W transient handover boundary
+        - Q5.3 Line W abnormal handover boundary
+        - Q5.4 pressure temperature and flow table control
+    bidder_answer:
+      - Line W shall be addressed as an interface-controlled handover route with bidder assumptions clearly identified.
+      - Nominal, transient, and abnormal operating boundaries shall be coordinated with the DBE interface action before final answer release.
+      - Bidder responses shall state implementation assumptions and required interfaces, not duplicate controlled table values.
+      - Pressure, temperature, and flow values shall not be restated in the answer and remain governed by the main input/interface tables.
+    dbe_actions:
+      - boundary: Line W nominal handover
+        action: DBE to confirm nominal Line W handover boundary and controlled interface-table references.
+        status: open
+      - boundary: Line W transient handover
+        action: DBE to confirm transient Line W handover boundary and interface response assumptions.
+        status: open
+      - boundary: Line W abnormal handover
+        action: DBE to confirm abnormal Line W handover boundary and fallback interface assumptions.
+        status: open
+    controlled_references:
+      pressure_temperature_flow: main input/interface tables
+      bidder_output_exclusions:
+        - slide references
+        - internal preparation slide numbers

--- a/rtm_integration/contract_followup/alat_clarification_bridge/templates/bidder_response.md
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/templates/bidder_response.md
@@ -1,0 +1,11 @@
+# ALaT Clarification Bridge — Bidder Response Template
+
+> Generated bidder-facing responses must be produced from the SSOT and reviewed before release.
+
+## Response rules
+
+- Preserve Q3/Q4/Q5 routing.
+- Use short bullet roll-ups.
+- Do not expose SCK internal sub-question numbers.
+- Do not duplicate pressure, temperature, or flow values from controlled input/interface tables.
+- Do not reference internal preparation material.

--- a/rtm_integration/contract_followup/alat_clarification_bridge/templates/management_summary.md
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/templates/management_summary.md
@@ -1,0 +1,24 @@
+# ALaT Clarification Bridge — Management Summary
+
+## Purpose
+
+Provide a YAML-driven single source of truth for the Q3/Q4/Q5 clarification route, linking bidder-facing answer roll-ups to RTM traceability, stakeholder ownership, and OFFER_list actions.
+
+## Scope
+
+- Q3 Recovery System
+- Q4 Line S
+- Q5 Line W
+- Balloon location, purification philosophy, and WSH storage planning basis
+- DBE action tracking for W/S nominal, transient, and abnormal handover boundaries
+
+## Management view
+
+| Question | Theme | Decision posture | RTM links | OFFER actions |
+| --- | --- | --- | --- | --- |
+{% for question in questions %}| {{ question.id }} | {{ question.theme }} | {{ question.decision_posture }} | {{ question.rtm_links | join(', ') }} | {{ question.offer_actions | join(', ') }} |
+{% endfor %}
+
+## Gate statement
+
+The bridge is merge-ready only when validation, generation, and workflow checks are present and passing. The PR must remain Draft until those controls exist.

--- a/rtm_integration/contract_followup/alat_clarification_bridge/templates/stakeholder_review.md
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/templates/stakeholder_review.md
@@ -1,0 +1,26 @@
+# ALaT Clarification Bridge — Stakeholder Review
+
+Review package generated from `ssot/alat_questions_ssot_v0_1.yaml`.
+
+## Review rules
+
+- Confirm that only Q3, Q4, and Q5 are present in the bidder-facing package.
+- Confirm that each parent question has RTM links and stakeholder ownership.
+- Confirm that pressure, temperature, and flow values remain controlled by the applicable input/interface tables.
+- Confirm that internal slide references do not appear in bidder-facing answers.
+- Confirm that internal sub-question identifiers are retained only for SCK traceability.
+
+## Stakeholder sign-off
+
+| Question | Discipline owner | Contract owner | RTM owner | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+{% for question in questions %}| {{ question.id }} | {{ question.stakeholders.discipline_owner }} | {{ question.stakeholders.contract_owner }} | {{ question.stakeholders.rtm_owner }} | Pending |  |
+{% endfor %}
+
+## Open review actions
+
+| Action | Owner | Due date | Closure evidence |
+| --- | --- | --- | --- |
+| Confirm Q3/Q4/Q5 route preservation. | Contract follow-up | TBD |  |
+| Confirm W/S handover DBE actions are complete. | DBE interface lead | TBD |  |
+| Confirm bidder-facing answers contain no slide references. | Technical editor | TBD |  |

--- a/rtm_integration/contract_followup/alat_clarification_bridge/tools/generate_bridge.py
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/tools/generate_bridge.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Generate bidder-facing and review artifacts from the ALaT SSOT."""
+from __future__ import annotations
+
+import argparse
+import html
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+BRIDGE_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SSOT = BRIDGE_ROOT / "ssot" / "alat_questions_ssot_v0_1.yaml"
+DEFAULT_OUTPUT = BRIDGE_ROOT / "build"
+
+
+def load_ssot(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("SSOT root must be a mapping")
+    return data
+
+
+def questions(data: dict[str, Any]) -> list[dict[str, Any]]:
+    return [item for item in data.get("questions", []) if isinstance(item, dict)]
+
+
+def md_list(items: list[Any]) -> str:
+    return "\n".join(f"- {item}" for item in items)
+
+
+def generate_markdown(data: dict[str, Any]) -> str:
+    lines: list[str] = [
+        "# ALaT Clarification Bridge — Bidder Answer Roll-up",
+        "",
+        "> Generated from `ssot/alat_questions_ssot_v0_1.yaml`. Do not edit generated output directly.",
+        "",
+        "## Control notes",
+        "",
+    ]
+    for rule in data.get("meta", {}).get("bidder_facing_rules", []):
+        if "Slides" in str(rule) or "slides" in str(rule):
+            continue
+        lines.append(f"- {rule}")
+    lines.append("")
+
+    for question in questions(data):
+        lines.extend(
+            [
+                f"## {question['id']} — {question['title']}",
+                "",
+                f"**Theme:** {question.get('theme', '')}",
+                "",
+                "**Bidder-facing roll-up:**",
+                "",
+                md_list(question.get("bidder_answer", [])),
+                "",
+                "**RTM links:** " + ", ".join(question.get("rtm_links", [])),
+                "",
+                "**OFFER actions:** " + ", ".join(question.get("offer_actions", [])),
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate_html(data: dict[str, Any]) -> str:
+    body: list[str] = [
+        "<!doctype html>",
+        '<html lang="en">',
+        "<head>",
+        '  <meta charset="utf-8">',
+        "  <title>ALaT Clarification Bridge</title>",
+        "  <style>body{font-family:Arial,sans-serif;max-width:960px;margin:2rem auto;line-height:1.5}code{background:#f3f3f3;padding:0.1rem 0.3rem}section{border-top:1px solid #ddd;padding-top:1rem}</style>",
+        "</head>",
+        "<body>",
+        "<h1>ALaT Clarification Bridge — Bidder Answer Roll-up</h1>",
+        "<p><strong>Generated from SSOT.</strong> Do not edit generated output directly.</p>",
+    ]
+    for question in questions(data):
+        body.extend(
+            [
+                "<section>",
+                f"<h2>{html.escape(question['id'])} — {html.escape(question['title'])}</h2>",
+                f"<p><strong>Theme:</strong> {html.escape(question.get('theme', ''))}</p>",
+                "<h3>Bidder-facing roll-up</h3>",
+                "<ul>",
+            ]
+        )
+        body.extend(f"<li>{html.escape(str(item))}</li>" for item in question.get("bidder_answer", []))
+        body.extend(
+            [
+                "</ul>",
+                f"<p><strong>RTM links:</strong> {html.escape(', '.join(question.get('rtm_links', [])))}</p>",
+                f"<p><strong>OFFER actions:</strong> {html.escape(', '.join(question.get('offer_actions', [])))}</p>",
+                "</section>",
+            ]
+        )
+    body.extend(["</body>", "</html>"])
+    return "\n".join(body) + "\n"
+
+
+def generate_review_summary(data: dict[str, Any]) -> str:
+    lines = ["# ALaT Clarification Bridge — Review Checklist", ""]
+    for question in questions(data):
+        stakeholders = question.get("stakeholders", {})
+        lines.extend(
+            [
+                f"## {question['id']} — {question['title']}",
+                "",
+                f"- [ ] RTM links confirmed: {', '.join(question.get('rtm_links', []))}",
+                f"- [ ] Discipline owner: {stakeholders.get('discipline_owner', '')}",
+                f"- [ ] Contract owner: {stakeholders.get('contract_owner', '')}",
+                f"- [ ] RTM owner: {stakeholders.get('rtm_owner', '')}",
+                "- [ ] Bidder-facing text uses short bullet roll-ups.",
+                "- [ ] Controlled pressure/temperature/flow values are not duplicated.",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate_excel_if_available(data: dict[str, Any], output_dir: Path) -> Path | None:
+    try:
+        from openpyxl import Workbook
+    except ImportError:
+        return None
+
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "ALaT Bridge"
+    sheet.append(["Question", "Title", "Theme", "RTM links", "OFFER actions", "Stakeholders"])
+    for question in questions(data):
+        stakeholders = question.get("stakeholders", {})
+        sheet.append(
+            [
+                question.get("id"),
+                question.get("title"),
+                question.get("theme"),
+                ", ".join(question.get("rtm_links", [])),
+                ", ".join(question.get("offer_actions", [])),
+                "; ".join(f"{key}: {value}" for key, value in stakeholders.items()),
+            ]
+        )
+    output_path = output_dir / "alat_clarification_bridge.xlsx"
+    workbook.save(output_path)
+    return output_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ssot", type=Path, default=DEFAULT_SSOT)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    try:
+        data = load_ssot(args.ssot)
+    except Exception as exc:  # noqa: BLE001 - report generation-friendly error
+        print(f"ERROR: failed to load SSOT: {exc}", file=sys.stderr)
+        return 1
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    markdown_path = args.out / "bidder_response.md"
+    html_path = args.out / "bidder_response.html"
+    review_path = args.out / "review_checklist.md"
+
+    markdown_path.write_text(generate_markdown(data), encoding="utf-8")
+    html_path.write_text(generate_html(data), encoding="utf-8")
+    review_path.write_text(generate_review_summary(data), encoding="utf-8")
+    excel_path = generate_excel_if_available(data, args.out)
+
+    outputs = [markdown_path, html_path, review_path]
+    if excel_path is not None:
+        outputs.append(excel_path)
+    print("Generated artifacts:")
+    for output in outputs:
+        print(f"- {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rtm_integration/contract_followup/alat_clarification_bridge/tools/generate_bridge.py
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/tools/generate_bridge.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import html
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -13,6 +14,7 @@ import yaml
 BRIDGE_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_SSOT = BRIDGE_ROOT / "ssot" / "alat_questions_ssot_v0_1.yaml"
 DEFAULT_OUTPUT = BRIDGE_ROOT / "build"
+TEMPLATE_DIR = BRIDGE_ROOT / "templates"
 
 
 def load_ssot(path: Path) -> dict[str, Any]:
@@ -29,6 +31,44 @@ def questions(data: dict[str, Any]) -> list[dict[str, Any]]:
 
 def md_list(items: list[Any]) -> str:
     return "\n".join(f"- {item}" for item in items)
+
+
+def resolve_question_value(question: dict[str, Any], expression: str) -> str:
+    expression = expression.strip()
+    join_match = re.fullmatch(r"question\.([\w.]+)\s*\|\s*join\('([^']*)'\)", expression)
+    if join_match:
+        value = nested_get(question, join_match.group(1))
+        return join_match.group(2).join(str(item) for item in value) if isinstance(value, list) else ""
+
+    direct_match = re.fullmatch(r"question\.([\w.]+)", expression)
+    if not direct_match:
+        return ""
+
+    value = nested_get(question, direct_match.group(1))
+    return str(value) if value is not None else ""
+
+
+def nested_get(mapping: dict[str, Any], dotted_path: str) -> Any:
+    current: Any = mapping
+    for key in dotted_path.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def render_question_template(template_path: Path, data: dict[str, Any]) -> str:
+    template = template_path.read_text(encoding="utf-8")
+    pattern = re.compile(r"{%\s*for\s+question\s+in\s+questions\s*%}(.*?){%\s*endfor\s*%}", re.DOTALL)
+
+    def replace_loop(match: re.Match[str]) -> str:
+        block = match.group(1)
+        rendered: list[str] = []
+        for question in questions(data):
+            rendered.append(re.sub(r"{{\s*(.*?)\s*}}", lambda item: resolve_question_value(question, item.group(1)), block))
+        return "".join(rendered)
+
+    return pattern.sub(replace_loop, template)
 
 
 def generate_markdown(data: dict[str, Any]) -> str:
@@ -165,13 +205,17 @@ def main() -> int:
     markdown_path = args.out / "bidder_response.md"
     html_path = args.out / "bidder_response.html"
     review_path = args.out / "review_checklist.md"
+    stakeholder_review_path = args.out / "stakeholder_review.md"
+    management_summary_path = args.out / "management_summary.md"
 
     markdown_path.write_text(generate_markdown(data), encoding="utf-8")
     html_path.write_text(generate_html(data), encoding="utf-8")
     review_path.write_text(generate_review_summary(data), encoding="utf-8")
+    stakeholder_review_path.write_text(render_question_template(TEMPLATE_DIR / "stakeholder_review.md", data), encoding="utf-8")
+    management_summary_path.write_text(render_question_template(TEMPLATE_DIR / "management_summary.md", data), encoding="utf-8")
     excel_path = generate_excel_if_available(data, args.out)
 
-    outputs = [markdown_path, html_path, review_path]
+    outputs = [markdown_path, html_path, review_path, stakeholder_review_path, management_summary_path]
     if excel_path is not None:
         outputs.append(excel_path)
     print("Generated artifacts:")

--- a/rtm_integration/contract_followup/alat_clarification_bridge/tools/validate_ssot.py
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/tools/validate_ssot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the ALaT Clarification Bridge YAML SSOT."""
+"""Validate the ALaT Clarification Bridge YAML SSOT and linked registers."""
 from __future__ import annotations
 
 import argparse
@@ -14,6 +14,10 @@ EXPECTED_QUESTIONS = ["Q3", "Q4", "Q5"]
 BOUNDARY_STATES = ["nominal", "transient", "abnormal"]
 BOUNDARY_LINES = ["Line W", "Line S"]
 FORBIDDEN_BIDDER_TERMS = ["slide", "slides"]
+BRIDGE_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SSOT = BRIDGE_ROOT / "ssot" / "alat_questions_ssot_v0_1.yaml"
+DEFAULT_RTM_LINKS = BRIDGE_ROOT / "RTM_LINKS.yaml"
+DEFAULT_OFFER_REGISTER = BRIDGE_ROOT / "OFFER_REGISTER.yaml"
 
 
 def load_yaml(path: Path) -> dict[str, Any]:
@@ -28,10 +32,67 @@ def as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
 
 
-def validate(data: dict[str, Any]) -> list[str]:
+def validate_register_links(
+    questions: list[dict[str, Any]],
+    rtm_data: dict[str, Any],
+    offer_data: dict[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+    question_ids = {str(question.get("id")) for question in questions}
+
+    rtm_links = rtm_data.get("rtm_links")
+    if not isinstance(rtm_links, dict):
+        return ["RTM_LINKS.yaml must contain an rtm_links mapping"]
+
+    offer_register = offer_data.get("offer_register")
+    if not isinstance(offer_register, list):
+        return ["OFFER_REGISTER.yaml must contain an offer_register list"]
+
+    offer_by_id: dict[str, dict[str, Any]] = {}
+    for entry in offer_register:
+        if not isinstance(entry, dict) or not entry.get("id"):
+            errors.append("OFFER_REGISTER.yaml entries must be mappings with an id")
+            continue
+        offer_id = str(entry["id"])
+        offer_by_id[offer_id] = entry
+        if str(entry.get("question")) not in question_ids:
+            errors.append(f"{offer_id}: OFFER register question must target one of {sorted(question_ids)}")
+
+    for link_id, entry in rtm_links.items():
+        if not isinstance(entry, dict):
+            errors.append(f"{link_id}: RTM link entry must be a mapping")
+            continue
+        if str(entry.get("question")) not in question_ids:
+            errors.append(f"{link_id}: RTM link question must target one of {sorted(question_ids)}")
+
+    for question in questions:
+        qid = str(question.get("id"))
+        for link_id in as_list(question.get("rtm_links")):
+            link = rtm_links.get(link_id)
+            if link is None:
+                errors.append(f"{qid}: RTM link {link_id!r} is not defined in RTM_LINKS.yaml")
+            elif str(link.get("question")) != qid:
+                errors.append(f"{qid}: RTM link {link_id!r} targets {link.get('question')!r}")
+
+        for offer_id in as_list(question.get("offer_actions")):
+            offer = offer_by_id.get(str(offer_id))
+            if offer is None:
+                errors.append(f"{qid}: OFFER action {offer_id!r} is not defined in OFFER_REGISTER.yaml")
+            elif str(offer.get("question")) != qid:
+                errors.append(f"{qid}: OFFER action {offer_id!r} targets {offer.get('question')!r}")
+
+    return errors
+
+
+def validate(
+    data: dict[str, Any],
+    rtm_data: dict[str, Any] | None = None,
+    offer_data: dict[str, Any] | None = None,
+) -> list[str]:
     errors: list[str] = []
     questions = as_list(data.get("questions"))
-    ids = [question.get("id") for question in questions if isinstance(question, dict)]
+    valid_questions = [question for question in questions if isinstance(question, dict)]
+    ids = [question.get("id") for question in valid_questions]
 
     if ids != EXPECTED_QUESTIONS:
         errors.append(f"questions must be exactly {EXPECTED_QUESTIONS}; found {ids}")
@@ -45,6 +106,9 @@ def validate(data: dict[str, Any]) -> list[str]:
         qid = question.get("id", "<missing>")
         if not as_list(question.get("rtm_links")):
             errors.append(f"{qid}: parent question must have at least one RTM link")
+
+        if not as_list(question.get("offer_actions")):
+            errors.append(f"{qid}: parent question must have at least one OFFER action")
 
         stakeholders = question.get("stakeholders")
         if not isinstance(stakeholders, dict):
@@ -79,33 +143,34 @@ def validate(data: dict[str, Any]) -> list[str]:
             if (line, state) not in dbe_coverage:
                 errors.append(f"DBE action missing for {line} {state} handover boundary")
 
+    if rtm_data is not None and offer_data is not None:
+        errors.extend(validate_register_links(valid_questions, rtm_data, offer_data))
+
     return errors
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "ssot",
-        nargs="?",
-        default=Path(__file__).resolve().parents[1] / "ssot" / "alat_questions_ssot_v0_1.yaml",
-        type=Path,
-        help="Path to the ALaT questions SSOT YAML file.",
-    )
+    parser.add_argument("ssot", nargs="?", default=DEFAULT_SSOT, type=Path, help="Path to the ALaT questions SSOT YAML file.")
+    parser.add_argument("--rtm-links", type=Path, default=DEFAULT_RTM_LINKS, help="Path to RTM_LINKS.yaml.")
+    parser.add_argument("--offer-register", type=Path, default=DEFAULT_OFFER_REGISTER, help="Path to OFFER_REGISTER.yaml.")
     args = parser.parse_args()
 
     try:
         data = load_yaml(args.ssot)
+        rtm_data = load_yaml(args.rtm_links)
+        offer_data = load_yaml(args.offer_register)
     except Exception as exc:  # noqa: BLE001 - report validation-friendly error
         print(f"ERROR: YAML failed to load: {exc}", file=sys.stderr)
         return 1
 
-    errors = validate(data)
+    errors = validate(data, rtm_data=rtm_data, offer_data=offer_data)
     if errors:
         for error in errors:
             print(f"ERROR: {error}", file=sys.stderr)
         return 1
 
-    print(f"OK: {args.ssot} contains exactly Q3, Q4, and Q5 with required traceability controls.")
+    print(f"OK: {args.ssot} contains exactly Q3, Q4, and Q5 with resolved RTM/OFFER controls.")
     return 0
 
 

--- a/rtm_integration/contract_followup/alat_clarification_bridge/tools/validate_ssot.py
+++ b/rtm_integration/contract_followup/alat_clarification_bridge/tools/validate_ssot.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Validate the ALaT Clarification Bridge YAML SSOT."""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+EXPECTED_QUESTIONS = ["Q3", "Q4", "Q5"]
+BOUNDARY_STATES = ["nominal", "transient", "abnormal"]
+BOUNDARY_LINES = ["Line W", "Line S"]
+FORBIDDEN_BIDDER_TERMS = ["slide", "slides"]
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a YAML mapping at the root")
+    return data
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def validate(data: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    questions = as_list(data.get("questions"))
+    ids = [question.get("id") for question in questions if isinstance(question, dict)]
+
+    if ids != EXPECTED_QUESTIONS:
+        errors.append(f"questions must be exactly {EXPECTED_QUESTIONS}; found {ids}")
+
+    dbe_coverage: set[tuple[str, str]] = set()
+    for question in questions:
+        if not isinstance(question, dict):
+            errors.append("each question must be a mapping")
+            continue
+
+        qid = question.get("id", "<missing>")
+        if not as_list(question.get("rtm_links")):
+            errors.append(f"{qid}: parent question must have at least one RTM link")
+
+        stakeholders = question.get("stakeholders")
+        if not isinstance(stakeholders, dict):
+            errors.append(f"{qid}: stakeholders mapping is required")
+        else:
+            for owner_key in ("discipline_owner", "contract_owner", "rtm_owner"):
+                if not stakeholders.get(owner_key):
+                    errors.append(f"{qid}: stakeholder {owner_key} is required")
+
+        bidder_answer = "\n".join(str(item) for item in as_list(question.get("bidder_answer"))).lower()
+        for forbidden in FORBIDDEN_BIDDER_TERMS:
+            if re.search(rf"\b{re.escape(forbidden)}\b", bidder_answer):
+                errors.append(f"{qid}: bidder-facing answer must not reference {forbidden!r}")
+
+        controlled = question.get("controlled_references")
+        if not isinstance(controlled, dict) or controlled.get("pressure_temperature_flow") != "main input/interface tables":
+            errors.append(f"{qid}: pressure/temperature/flow must reference main input/interface tables")
+
+        for action in as_list(question.get("dbe_actions")):
+            if not isinstance(action, dict):
+                continue
+            boundary = str(action.get("boundary", ""))
+            action_text = str(action.get("action", ""))
+            combined = f"{boundary} {action_text}"
+            for line in BOUNDARY_LINES:
+                for state in BOUNDARY_STATES:
+                    if line.lower() in combined.lower() and state in combined.lower():
+                        dbe_coverage.add((line, state))
+
+    for line in BOUNDARY_LINES:
+        for state in BOUNDARY_STATES:
+            if (line, state) not in dbe_coverage:
+                errors.append(f"DBE action missing for {line} {state} handover boundary")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "ssot",
+        nargs="?",
+        default=Path(__file__).resolve().parents[1] / "ssot" / "alat_questions_ssot_v0_1.yaml",
+        type=Path,
+        help="Path to the ALaT questions SSOT YAML file.",
+    )
+    args = parser.parse_args()
+
+    try:
+        data = load_yaml(args.ssot)
+    except Exception as exc:  # noqa: BLE001 - report validation-friendly error
+        print(f"ERROR: YAML failed to load: {exc}", file=sys.stderr)
+        return 1
+
+    errors = validate(data)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {args.ssot} contains exactly Q3, Q4, and Q5 with required traceability controls.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_alat_clarification_bridge.py
+++ b/tests/test_alat_clarification_bridge.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+BRIDGE_ROOT = Path(__file__).resolve().parents[1] / "rtm_integration" / "contract_followup" / "alat_clarification_bridge"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_validator_accepts_current_ssot_and_resolves_registers():
+    validator = load_module("alat_validate_ssot", BRIDGE_ROOT / "tools" / "validate_ssot.py")
+
+    errors = validator.validate(
+        load_yaml(BRIDGE_ROOT / "ssot" / "alat_questions_ssot_v0_1.yaml"),
+        rtm_data=load_yaml(BRIDGE_ROOT / "RTM_LINKS.yaml"),
+        offer_data=load_yaml(BRIDGE_ROOT / "OFFER_REGISTER.yaml"),
+    )
+
+    assert errors == []
+
+
+def test_validator_rejects_missing_rtm_link():
+    validator = load_module("alat_validate_ssot_negative", BRIDGE_ROOT / "tools" / "validate_ssot.py")
+    ssot = load_yaml(BRIDGE_ROOT / "ssot" / "alat_questions_ssot_v0_1.yaml")
+    broken_ssot = copy.deepcopy(ssot)
+    broken_ssot["questions"][0]["rtm_links"] = []
+
+    errors = validator.validate(
+        broken_ssot,
+        rtm_data=load_yaml(BRIDGE_ROOT / "RTM_LINKS.yaml"),
+        offer_data=load_yaml(BRIDGE_ROOT / "OFFER_REGISTER.yaml"),
+    )
+
+    assert any("parent question must have at least one RTM link" in error for error in errors)
+
+
+def test_validator_rejects_unresolved_register_references():
+    validator = load_module("alat_validate_ssot_unresolved", BRIDGE_ROOT / "tools" / "validate_ssot.py")
+    ssot = load_yaml(BRIDGE_ROOT / "ssot" / "alat_questions_ssot_v0_1.yaml")
+    broken_ssot = copy.deepcopy(ssot)
+    broken_ssot["questions"][0]["rtm_links"].append("RTM-ALAT-MISSING")
+    broken_ssot["questions"][0]["offer_actions"].append("OFFER-MISSING")
+
+    errors = validator.validate(
+        broken_ssot,
+        rtm_data=load_yaml(BRIDGE_ROOT / "RTM_LINKS.yaml"),
+        offer_data=load_yaml(BRIDGE_ROOT / "OFFER_REGISTER.yaml"),
+    )
+
+    assert any("RTM link 'RTM-ALAT-MISSING' is not defined" in error for error in errors)
+    assert any("OFFER action 'OFFER-MISSING' is not defined" in error for error in errors)
+
+
+def test_generator_writes_template_outputs(tmp_path):
+    generator = load_module("alat_generate_bridge", BRIDGE_ROOT / "tools" / "generate_bridge.py")
+    ssot = load_yaml(BRIDGE_ROOT / "ssot" / "alat_questions_ssot_v0_1.yaml")
+
+    outputs = {
+        "bidder_response.md": generator.generate_markdown(ssot),
+        "bidder_response.html": generator.generate_html(ssot),
+        "review_checklist.md": generator.generate_review_summary(ssot),
+        "stakeholder_review.md": generator.render_question_template(BRIDGE_ROOT / "templates" / "stakeholder_review.md", ssot),
+        "management_summary.md": generator.render_question_template(BRIDGE_ROOT / "templates" / "management_summary.md", ssot),
+    }
+    for name, content in outputs.items():
+        (tmp_path / name).write_text(content, encoding="utf-8")
+
+    for name in outputs:
+        assert (tmp_path / name).is_file()
+    assert "{{" not in (tmp_path / "stakeholder_review.md").read_text(encoding="utf-8")
+    assert "{{" not in (tmp_path / "management_summary.md").read_text(encoding="utf-8")

--- a/tests/test_alat_clarification_bridge.py
+++ b/tests/test_alat_clarification_bridge.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import sys
+import types
 from pathlib import Path
 
 import yaml
@@ -84,3 +86,33 @@ def test_generator_writes_template_outputs(tmp_path):
         assert (tmp_path / name).is_file()
     assert "{{" not in (tmp_path / "stakeholder_review.md").read_text(encoding="utf-8")
     assert "{{" not in (tmp_path / "management_summary.md").read_text(encoding="utf-8")
+
+
+def test_excel_generation_path_when_openpyxl_is_available(tmp_path, monkeypatch):
+    generator = load_module("alat_generate_bridge_excel", BRIDGE_ROOT / "tools" / "generate_bridge.py")
+    ssot = load_yaml(BRIDGE_ROOT / "ssot" / "alat_questions_ssot_v0_1.yaml")
+
+    class FakeSheet:
+        title = ""
+
+        def __init__(self):
+            self.rows = []
+
+        def append(self, row):
+            self.rows.append(row)
+
+    class FakeWorkbook:
+        def __init__(self):
+            self.active = FakeSheet()
+
+        def save(self, output_path):
+            output_path.write_text("fake workbook", encoding="utf-8")
+
+    fake_openpyxl = types.ModuleType("openpyxl")
+    fake_openpyxl.Workbook = FakeWorkbook
+    monkeypatch.setitem(sys.modules, "openpyxl", fake_openpyxl)
+
+    output_path = generator.generate_excel_if_available(ssot, tmp_path)
+
+    assert output_path == tmp_path / "alat_clarification_bridge.xlsx"
+    assert output_path.read_text(encoding="utf-8") == "fake workbook"


### PR DESCRIPTION
### Motivation

- Provide a YAML-driven single source of truth (SSOT) for the ALaT Q3/Q4/Q5 clarification route to support RTM traceability, Contract Follow-up, and OFFER_list management.
- Enforce bidder-facing constraints (short bullet roll-ups, no slide references, controlled pressure/temperature/flow values) and DBE confirmation for W/S handover boundaries.
- Produce predictable bidder-facing artifacts (Markdown/HTML and optional Excel) and formalize a CI gate to keep the PR in Draft until controls run successfully.

### Description

- Add the SSOT file `rtm_integration/contract_followup/alat_clarification_bridge/ssot/alat_questions_ssot_v0_1.yaml` containing exactly Q3, Q4, and Q5 with stakeholder ownership, RTM links, internal traceability, DBE actions, and bidder-facing roll-ups.
- Add registers `OFFER_REGISTER.yaml` and `RTM_LINKS.yaml` to capture OFFER actions and RTM linkage for the bridge.
- Add a validator `tools/validate_ssot.py` that enforces YAML loadability, exact presence of Q3/Q4/Q5, RTM links, stakeholder ownership, DBE boundary action coverage for Line W and Line S across nominal/transient/abnormal states, controlled reference checks, and forbids bidder-facing slide references.
- Add a generator `tools/generate_bridge.py` that emits bidder-facing Markdown and HTML, a review checklist Markdown, and an optional Excel workbook when `openpyxl` is available.
- Add templates and docs: `templates/stakeholder_review.md`, `templates/management_summary.md`, `templates/bidder_response.md`, `README.md`, and the merge-gate `docs/review_checklist_merge_gate.md` describing the Draft PR gate and required checks.
- Add a GitHub Actions workflow `.github/workflows/build-clarification-bridge.yml` to install deps, run the validator, run the generator, assert generated `bidder_response.md` and `bidder_response.html` exist, and upload artifacts.

### Testing

- Ran the SSOT validator with `python rtm_integration/contract_followup/alat_clarification_bridge/tools/validate_ssot.py`, which completed successfully and reported the SSOT contains the required controls.
- Ran the generator with `python rtm_integration/contract_followup/alat_clarification_bridge/tools/generate_bridge.py`, which produced `build/bidder_response.md`, `build/bidder_response.html`, and `build/review_checklist.md` (Excel produced when `openpyxl` is available).
- Verified artifact existence via shell checks `test -f .../build/bidder_response.md` and `test -f .../build/bidder_response.html`, both passed.
- Verified Python source sanity with `python -m py_compile` for the added tools, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2277e76f48832e93c0f7359bab20c3)