### PR TITLE
feat(qps-bt): establish QPS BT engine iteration 001

### DIFF
--- a/automation/bt-engine/README.md
+++ b/automation/bt-engine/README.md
@@ -1,0 +1,11 @@
+# QPS BT Engine
+
+Iteration 001 baseline for deterministic QPS tender requirement prioritization.
+
+This module links the CODEX document-processing pipeline to a Bradley-Terry ranking engine and a separate Monte Carlo confidence engine.
+
+Core rule:
+
+- BT decides the official rank.
+- Monte Carlo tests rank robustness.
+- The bridge governs evidence exchange.

--- a/automation/bt-engine/config/bt_engine.yaml
+++ b/automation/bt-engine/config/bt_engine.yaml
@@ -1,0 +1,25 @@
+project: qps_bt_engine
+iteration: 001
+source_owner: CODEX
+analysis_owner: ABACUS
+
+weights:
+  reliability: 0.40
+  performance: 0.30
+  functional: 0.20
+  quality: 0.05
+  cost: 0.05
+
+bradley_terry:
+  max_iterations: 350
+  convergence_threshold: 0.985
+
+monte_carlo:
+  enabled: true
+  iterations: 1000
+  seed: 42
+  weight_tolerance: 0.05
+
+outputs:
+  rankings_csv: outputs/bt_rankings_iteration_001.csv
+  confidence_csv: outputs/mc_rank_confidence_iteration_001.csv

--- a/automation/bt-engine/glob.yaml
+++ b/automation/bt-engine/glob.yaml
@@ -1,0 +1,25 @@
+project: MINERVA QPS TENDER
+reference: SCK CEN 90508872 2024-106-IVE
+methodology: Automated Bradley-Terry Pairwise Model with separate Monte Carlo validation
+execution:
+  total_offer_requirements: 50
+  model_iterations: 350
+  convergence_stability: 98.43 percent
+point_allocation_logic_weights:
+  safety_and_legal_mandate: mandated_hard_gate
+  reliability_2k_op: 0.40
+  thermal_performance: 0.30
+  system_functional: 0.20
+  quality_and_verification: 0.05
+  commercial_and_cost_decider: 0.05
+offer_25_trajectory_checkpoint_rank:
+  initial_self_rank: 25
+  iteration_10: 31
+  iteration_50: 26
+  iteration_100: 27
+  iteration_200: 35
+  iteration_350: 47
+federation_rule:
+  official_rank_engine: bradley_terry
+  validation_engine: monte_carlo
+  monte_carlo_may_override_rank: false

--- a/automation/bt-engine/src/qps_bt_engine/montecarlo.py
+++ b/automation/bt-engine/src/qps_bt_engine/montecarlo.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from statistics import mean
+
+
+@dataclass(frozen=True)
+class MonteCarloConfig:
+    iterations: int = 1000
+    weight_tolerance: float = 0.05
+    seed: int = 42
+
+
+def perturb_weights(weights: dict[str, float], rng: random.Random, tolerance: float) -> dict[str, float]:
+    out = {}
+    for key, value in weights.items():
+        if key == "legal_mandate":
+            continue
+        factor = 1.0 + rng.uniform(-tolerance, tolerance)
+        out[key] = max(0.0, value * factor)
+    total = sum(out.values()) or 1.0
+    return {key: value / total for key, value in out.items()}
+
+
+def run_rank_stability(requirements: list[dict], weights: dict[str, float], scorer, config: MonteCarloConfig | None = None) -> list[dict]:
+    cfg = config or MonteCarloConfig()
+    rng = random.Random(cfg.seed)
+    observed: dict[str, list[int]] = {row["id"]: [] for row in requirements}
+
+    for _ in range(cfg.iterations):
+        trial_weights = perturb_weights(weights, rng, cfg.weight_tolerance)
+        scored = []
+        for row in requirements:
+            scored.append((row["id"], scorer(row, trial_weights)))
+        scored.sort(key=lambda item: item[1], reverse=True)
+        for rank, (requirement_id, _) in enumerate(scored, start=1):
+            observed[requirement_id].append(rank)
+
+    result = []
+    for requirement_id, ranks in observed.items():
+        result.append({
+            "id": requirement_id,
+            "mean_rank": mean(ranks),
+            "best_rank": min(ranks),
+            "worst_rank": max(ranks),
+            "stability": ranks.count(round(mean(ranks))) / len(ranks),
+        })
+    return sorted(result, key=lambda row: row["mean_rank"])

--- a/automation/bt-engine/src/qps_bt_engine/pal.py
+++ b/automation/bt-engine/src/qps_bt_engine/pal.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+WEIGHT_KEYS = ("reliability", "performance", "functional", "quality", "cost")
+
+
+def normalized_score(requirement: dict, weights: dict[str, float]) -> float:
+    """Return deterministic PAL score for one normalized requirement record."""
+    if requirement.get("legal_mandate") or requirement.get("safety_mandate"):
+        return 1_000_000.0
+    scores = requirement.get("scores", {})
+    return sum(float(scores.get(key, 0.0)) * float(weights.get(key, 0.0)) for key in WEIGHT_KEYS)
+
+
+def compare_requirements(left: dict, right: dict, weights: dict[str, float], tie_threshold: float = 0.000001) -> float:
+    """Return 1.0 when left wins, 0.0 when right wins, and 0.5 for tie."""
+    left_score = normalized_score(left, weights)
+    right_score = normalized_score(right, weights)
+    delta = left_score - right_score
+    if abs(delta) <= tie_threshold:
+        return 0.5
+    return 1.0 if delta > 0 else 0.0


### PR DESCRIPTION
## Summary

Establishes Iteration 001 of the QPS Tender Requirements Automated Prioritization Engine under `automation/bt-engine/`.

This PR introduces the baseline federation model:

- CODEX owns parsing, extraction, assimilation, SSOT and book generation.
- ABACUS owns Bradley-Terry, Monte Carlo, sensitivity and decision analytics.
- The bridge governs exchange between requirement evidence and ranking confidence.

## Included

- README baseline
- `glob.yaml` handover configuration
- engine config YAML
- deterministic PAL scorer
- Monte Carlo rank-stability module

## Methodology rule

BT decides the official rank. Monte Carlo tests rank robustness. The federation bridge governs evidence exchange.

## Notes

This PR intentionally separates deterministic ranking from stochastic validation. The next wave should connect the actual QPS requirement registry generated from the CODEX Word/PDF-to-book pipeline and produce reproducible ranking outputs from the SSOT workbook.