### PR TITLE
fix: resolve CODEX parse blockers

### DIFF
--- a/src/gistau_ch15/visualization/pages_artifact_refresh.py
+++ b/src/gistau_ch15/visualization/pages_artifact_refresh.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Optional
 
 from gistau_ch15.visualization.regenerate_overlay_json import regenerate
-from gistau_ch15.visualization.trace_json_export import (
-    PlotlyTraceJSONExporter,
-)
+from gistau_ch15.visualization.trace_json_export import PlotlyTraceJSONExporter
 
 
 class PagesArtifactRefresh:
@@ -14,14 +13,14 @@ class PagesArtifactRefresh:
     def refresh(
         self,
         *,
-        overlay_output: Path | None = None,
-        trace_output: Path | None = None,
+        overlay_output: Optional[Path] = None,
+        trace_output: Optional[Path] = None,
     ) -> list[Path]:
         """Refresh artifacts, optionally redirecting outputs.
 
         Args:
-            overlay_output: Optional path for thermo_visual_overlay_seed.json
-            trace_output: Optional path for plotly_trace_export.json
+            overlay_output: Optional path for thermo_visual_overlay_seed.json.
+            trace_output: Optional path for plotly_trace_export.json.
         """
         outputs: list[Path] = []
 
@@ -30,9 +29,10 @@ class PagesArtifactRefresh:
         else:
             outputs.append(regenerate())
 
+        exporter = PlotlyTraceJSONExporter()
         if trace_output is not None:
-            outputs.append(PlotlyTraceJSONExporter().export(trace_output))
+            outputs.append(exporter.export(trace_output))
         else:
-            outputs.append(PlotlyTraceJSONExporter().export())
+            outputs.append(exporter.export())
 
         return outputs

--- a/visuals/convergence_surface_3d.py
+++ b/visuals/convergence_surface_3d.py
@@ -1,47 +1,122 @@
-import plotly.graph_objects as go
 from pathlib import Path
+from typing import Any
+
 import yaml
 
-waves = ['A1','A2','A3','A4','A5','A6','A7','A8','A9']
-governance = [18,35,49,63,74,88,92,94,95]
-thermo = [2,4,9,14,22,31,38,44,52]
-publication = [8,22,35,48,61,76,83,88,91]
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST_PATH = ROOT / "MANIFEST" / "WAVE_PROGRESSION.yaml"
+DEFAULT_OUTPUT_PATH = ROOT / "outputs" / "html" / "convergence_surface_3d.html"
 
-def main() -> None:
-    # Load wave metrics from governed manifest
-    manifest_path = Path(__file__).parent.parent / 'MANIFEST' / 'WAVE_PROGRESSION.yaml'
-    with manifest_path.open('r', encoding='utf-8') as f:
-        data = yaml.safe_load(f)
-    
-    waves = [w['wave'] for w in data['waves']]
-    wave_metrics = data['wave_metrics']
-    governance = [wave_metrics['renderer_governance_progress'][w] for w in waves]
-    thermo = [wave_metrics['thermodynamic_progress'][w] for w in waves]
-    publication = [wave_metrics['publication_progress'][w] for w in waves]
 
-fig.update_layout(
-    title='A9 Convergence Topology Surface',
-    scene=dict(
-        xaxis_title='Governance',
-        yaxis_title='Publication',
-        zaxis_title='Thermodynamics',
-    ),
-)
+def _metric_series(
+    wave_metrics: dict[str, Any],
+    metric_name: str,
+    waves: list[str],
+) -> list[float]:
+    metric_payload = wave_metrics.get(metric_name)
+    if not isinstance(metric_payload, dict):
+        raise ValueError(f"wave_metrics.{metric_name} must be a mapping")
 
-    fig.update_layout(
-        title='A8 Convergence Topology Surface',
-        scene=dict(
-            xaxis_title='Governance',
-            yaxis_title='Publication',
-            zaxis_title='Thermodynamics',
-        ),
+    values: list[float] = []
+    for wave in waves:
+        value = metric_payload.get(wave)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"wave_metrics.{metric_name}.{wave} must be numeric")
+        values.append(float(value))
+    return values
+
+
+def load_convergence_metrics(
+    manifest_path: Path = DEFAULT_MANIFEST_PATH,
+) -> tuple[list[str], list[float], list[float], list[float]]:
+    if not manifest_path.exists():
+        raise FileNotFoundError(manifest_path)
+
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle)
+
+    if not isinstance(payload, dict):
+        raise ValueError("WAVE_PROGRESSION manifest must be a mapping")
+
+    waves_payload = payload.get("waves")
+    if not isinstance(waves_payload, list):
+        raise ValueError('"waves" must be a list')
+
+    waves: list[str] = []
+    for index, item in enumerate(waves_payload):
+        if not isinstance(item, dict) or "wave" not in item:
+            raise ValueError(f"waves[{index}] must include wave")
+        waves.append(str(item["wave"]))
+
+    wave_metrics = payload.get("wave_metrics")
+    if not isinstance(wave_metrics, dict):
+        raise ValueError('"wave_metrics" must be a mapping')
+
+    governance = _metric_series(wave_metrics, "renderer_governance_progress", waves)
+    thermodynamics = _metric_series(wave_metrics, "thermodynamic_progress", waves)
+    publication = _metric_series(wave_metrics, "publication_progress", waves)
+    return waves, governance, publication, thermodynamics
+
+
+def build_convergence_surface_figure(manifest_path: Path = DEFAULT_MANIFEST_PATH):
+    try:
+        import plotly.graph_objects as go
+    except ImportError as exc:
+        raise SystemExit(
+            "Plotly is required to generate the convergence surface. "
+            "Install it with: pip install plotly"
+        ) from exc
+
+    waves, governance, publication, thermodynamics = load_convergence_metrics(manifest_path)
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter3d(
+            x=governance,
+            y=publication,
+            z=thermodynamics,
+            mode="lines+markers+text",
+            text=waves,
+            textposition="top center",
+            name="Wave convergence path",
+            hovertemplate=(
+                "Wave %{text}<br>"
+                "Governance: %{x:.1f}%<br>"
+                "Publication: %{y:.1f}%<br>"
+                "Thermodynamics: %{z:.1f}%<extra></extra>"
+            ),
+        )
+    )
+    fig.add_trace(
+        go.Mesh3d(
+            x=governance,
+            y=publication,
+            z=thermodynamics,
+            opacity=0.2,
+            name="Convergence surface",
+            hoverinfo="skip",
+            showscale=False,
+        )
     )
 
-    output_path = Path(__file__).resolve().parent.parent / 'outputs' / 'html' / 'convergence_surface_3d.html'
+    fig.update_layout(
+        title="A9 Convergence Topology Surface",
+        scene=dict(
+            xaxis_title="Governance",
+            yaxis_title="Publication",
+            zaxis_title="Thermodynamics",
+        ),
+    )
+    return fig
+
+
+def main() -> None:
+    output_path = DEFAULT_OUTPUT_PATH
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig = build_convergence_surface_figure()
     fig.write_html(str(output_path))
-    print(f'generated {output_path}')
+    print(f"generated {output_path}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- resolves CODEX-PARSE-001 by normalizing `pages_artifact_refresh.py` imports/type syntax and reusing a single exporter instance
- resolves CODEX-PARSE-002 by restoring syntactically valid convergence surface generation, including manifest validation and explicit Plotly figure construction

## Validation

- reviewed against CODEX_SESSION.md blocker instructions
- syntax-level fix only; unable to run local `rex` module scanner from this connector session

## Tracker

- mark `GBOGEB_CODEX.blocking_items.CODEX-PARSE-001` as `RESOLVED`
- mark `GBOGEB_CODEX.blocking_items.CODEX-PARSE-002` as `RESOLVED`