### PR TITLE
feat(qps-roundtrip): Wave 1 governance and release tooling

### DIFF
--- a/.github/workflows/qps-roundtrip-policy.yml
+++ b/.github/workflows/qps-roundtrip-policy.yml
@@ -66,3 +66,39 @@ jobs:
           if (-not (Test-Path (Join-Path $root 'MANIFEST.sha256'))) { throw 'Manifest was not created.' }
           $lines = @(Get-Content (Join-Path $root 'MANIFEST.sha256') | Where-Object { $_ -notmatch '^#' -and $_.Trim() })
           if ($lines.Count -ne 2) { throw "Expected 2 manifest records, got $($lines.Count)." }
+
+      - name: Synthetic immutable publication smoke test
+        shell: pwsh
+        run: |
+          $dist = Join-Path $env:RUNNER_TEMP 'qps-dist-smoke'
+          $releaseRoot = Join-Path $env:RUNNER_TEMP 'qps-release-root'
+          New-Item -ItemType Directory -Force $dist | Out-Null
+          New-Item -ItemType Directory -Force (Join-Path $dist 'nested') | Out-Null
+          Set-Content -Path (Join-Path $dist 'BUILD_META.json') -Value '{"qa":{"status":"PASS"}}' -NoNewline
+          Set-Content -Path (Join-Path $dist 'RELEASE_NOTES.md') -Value '# synthetic release' -NoNewline
+          Set-Content -Path (Join-Path $dist 'QA_REPORT.md') -Value '# PASS' -NoNewline
+          Set-Content -Path (Join-Path $dist 'nested/model.txt') -Value 'semantic-model' -NoNewline
+          New-Item -ItemType Directory -Force $releaseRoot | Out-Null
+
+          $result = & ./07_ops/qps_roundtrip/Publish-QpsRelease.ps1 `
+            -SourceDist $dist `
+            -ReleaseId 'synthetic-v1' `
+            -ReleaseRoot $releaseRoot `
+            -CreateOfficeReviewCopy | ConvertFrom-Json
+
+          if ($result.result -ne 'PASS') { throw 'Synthetic publication did not return PASS.' }
+          $published = Join-Path $releaseRoot 'synthetic-v1'
+          if (-not (Test-Path (Join-Path $published 'nested/model.txt'))) { throw 'Nested release content was not copied.' }
+          if (-not (Test-Path (Join-Path $published 'MANIFEST.sha256'))) { throw 'Published manifest is missing.' }
+
+          $costRoot = Split-Path -Parent $releaseRoot
+          $review = Join-Path (Join-Path $costRoot '20_WORKING_REVIEW') 'synthetic-v1'
+          if (-not (Test-Path (Join-Path $review 'nested/model.txt'))) { throw 'Office review copy was not created.' }
+
+          $duplicateFailed = $false
+          try {
+            & ./07_ops/qps_roundtrip/Publish-QpsRelease.ps1 -SourceDist $dist -ReleaseId 'synthetic-v1' -ReleaseRoot $releaseRoot | Out-Null
+          } catch {
+            $duplicateFailed = $true
+          }
+          if (-not $duplicateFailed) { throw 'Publisher did not protect the immutable release ID.' }

--- a/.github/workflows/qps-roundtrip-policy.yml
+++ b/.github/workflows/qps-roundtrip-policy.yml
@@ -1,0 +1,68 @@
+name: QPS roundtrip policy
+
+on:
+  pull_request:
+    paths:
+      - '07_ops/qps_roundtrip/**'
+      - '.github/workflows/qps-roundtrip-policy.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '07_ops/qps_roundtrip/**'
+      - '.github/workflows/qps-roundtrip-policy.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  policy-and-syntax:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate controlled-path binary policy
+        shell: pwsh
+        run: |
+          if ('${{ github.event_name }}' -eq 'pull_request') {
+            git fetch origin '${{ github.base_ref }}' --depth=1
+            $files = @(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          } else {
+            $files = @(git show --pretty='' --name-only HEAD)
+          }
+          & ./07_ops/qps_roundtrip/Test-QpsTextOnlyPolicy.ps1 -RepositoryPath . -FileList $files
+
+      - name: Parse PowerShell source
+        shell: pwsh
+        run: |
+          $failed = $false
+          Get-ChildItem ./07_ops/qps_roundtrip -Filter *.ps1 -File | ForEach-Object {
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$errors) | Out-Null
+            if ($errors.Count -gt 0) {
+              Write-Host "::error file=$($_.FullName)::$($errors | Out-String)"
+              $failed = $true
+            }
+          }
+          if ($failed) { exit 1 }
+
+      - name: Validate BUILD_META template JSON
+        shell: pwsh
+        run: |
+          Get-Content ./07_ops/qps_roundtrip/BUILD_META.template.json -Raw | ConvertFrom-Json | Out-Null
+
+      - name: Synthetic manifest smoke test
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:RUNNER_TEMP 'qps-manifest-smoke'
+          New-Item -ItemType Directory -Force $root | Out-Null
+          Set-Content -Path (Join-Path $root 'a.txt') -Value 'alpha' -NoNewline
+          New-Item -ItemType Directory -Force (Join-Path $root 'nested') | Out-Null
+          Set-Content -Path (Join-Path $root 'nested/b.txt') -Value 'beta' -NoNewline
+          & ./07_ops/qps_roundtrip/Get-QpsRecursiveManifest.ps1 -Root $root | Write-Host
+          if (-not (Test-Path (Join-Path $root 'MANIFEST.sha256'))) { throw 'Manifest was not created.' }
+          $lines = @(Get-Content (Join-Path $root 'MANIFEST.sha256') | Where-Object { $_ -notmatch '^#' -and $_.Trim() })
+          if ($lines.Count -ne 2) { throw "Expected 2 manifest records, got $($lines.Count)." }

--- a/07_ops/qps_roundtrip/BUILD_META.template.json
+++ b/07_ops/qps_roundtrip/BUILD_META.template.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "control_id": "GOV-001",
+  "release_id": "<version>_<short_commit>_<build_id>",
+  "generated_utc": "<ISO-8601 UTC>",
+  "repositories": {
+    "abacus": {
+      "repository": "GBOGEB/ABACUS",
+      "commit": "<full SHA>"
+    },
+    "codex": {
+      "repository": "GBOGEB/CODEX",
+      "commit": "<full SHA>"
+    },
+    "private_overlay": {
+      "repository": "GBOGEB/cryoplant-project",
+      "commit": "<full SHA>"
+    }
+  },
+  "source_tree_sha256": "<SHA-256>",
+  "evidence_registry_sha256": "<SHA-256>",
+  "evidence": [],
+  "semantic_outputs": [],
+  "artifacts": [],
+  "qa": {
+    "status": "<PASS|FAIL>",
+    "report": "QA_REPORT.md"
+  },
+  "publication": {
+    "release_root_env": "QPS_RELEASE_ROOT",
+    "immutable_release": true,
+    "office_review_copy": true
+  }
+}

--- a/07_ops/qps_roundtrip/Get-QpsRecursiveManifest.ps1
+++ b/07_ops/qps_roundtrip/Get-QpsRecursiveManifest.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Root,
+    [string]$OutputPath = (Join-Path $Root 'MANIFEST.sha256'),
+    [string[]]$ExcludeRelativePaths = @('MANIFEST.sha256')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$resolvedRoot = (Resolve-Path -LiteralPath $Root).Path
+$outputFullPath = [System.IO.Path]::GetFullPath($OutputPath)
+
+$excludeSet = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+)
+foreach ($item in $ExcludeRelativePaths) {
+    [void]$excludeSet.Add($item.Replace('\', '/'))
+}
+
+$records = foreach ($file in Get-ChildItem -LiteralPath $resolvedRoot -File -Recurse | Sort-Object FullName) {
+    if ($file.FullName -eq $outputFullPath) {
+        continue
+    }
+
+    $relative = [System.IO.Path]::GetRelativePath($resolvedRoot, $file.FullName).Replace('\', '/')
+    if ($excludeSet.Contains($relative)) {
+        continue
+    }
+
+    $hash = Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256
+    [pscustomobject]@{
+        relative_path = $relative
+        sha256 = $hash.Hash.ToLowerInvariant()
+        size_bytes = $file.Length
+    }
+}
+
+$parent = Split-Path -Parent $OutputPath
+if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+}
+
+$lines = @(
+    '# SHA-256 recursive manifest'
+    "# root=$resolvedRoot"
+    "# generated_utc=$([DateTime]::UtcNow.ToString('o'))"
+)
+$lines += $records | ForEach-Object { '{0}  {1}' -f $_.sha256, $_.relative_path }
+
+[System.IO.File]::WriteAllLines($outputFullPath, $lines, [System.Text.UTF8Encoding]::new($false))
+
+[ordered]@{
+    root = $resolvedRoot
+    output = $outputFullPath
+    file_count = @($records).Count
+    result = 'PASS'
+} | ConvertTo-Json -Depth 3

--- a/07_ops/qps_roundtrip/Initialize-QpsWorkspace.ps1
+++ b/07_ops/qps_roundtrip/Initialize-QpsWorkspace.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$RepoRoot = 'C:\DEV\REPOS',
+    [string]$WorkspaceRoot = 'C:\DEV\WORKSPACES\qps-cost',
+    [string]$EvidenceRoot = $env:QPS_EVIDENCE_ROOT,
+    [string]$ReleaseRoot = $env:QPS_RELEASE_ROOT,
+    [switch]$CreateOneDriveFolders
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Ensure-Directory {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        if ($PSCmdlet.ShouldProcess($Path, 'Create directory')) {
+            New-Item -ItemType Directory -Path $Path -Force | Out-Null
+        }
+    }
+}
+
+$localDirectories = @(
+    $RepoRoot,
+    $WorkspaceRoot,
+    (Join-Path $WorkspaceRoot '_verify'),
+    (Join-Path $WorkspaceRoot '_logs')
+)
+
+foreach ($directory in $localDirectories) {
+    Ensure-Directory -Path $directory
+}
+
+if ($CreateOneDriveFolders) {
+    if ([string]::IsNullOrWhiteSpace($EvidenceRoot)) {
+        throw 'QPS_EVIDENCE_ROOT is not set and -EvidenceRoot was not provided.'
+    }
+    if ([string]::IsNullOrWhiteSpace($ReleaseRoot)) {
+        throw 'QPS_RELEASE_ROOT is not set and -ReleaseRoot was not provided.'
+    }
+
+    $costRoot = Split-Path -Parent $ReleaseRoot
+    $oneDriveDirectories = @(
+        $EvidenceRoot,
+        $ReleaseRoot,
+        (Join-Path $costRoot '20_WORKING_REVIEW'),
+        (Join-Path $costRoot '90_ARCHIVE')
+    )
+
+    foreach ($directory in $oneDriveDirectories) {
+        Ensure-Directory -Path $directory
+    }
+}
+
+$summary = [ordered]@{
+    repo_root = $RepoRoot
+    workspace_root = $WorkspaceRoot
+    evidence_root = $EvidenceRoot
+    release_root = $ReleaseRoot
+    timestamp_utc = [DateTime]::UtcNow.ToString('o')
+}
+
+$summary | ConvertTo-Json -Depth 3

--- a/07_ops/qps_roundtrip/Publish-QpsRelease.ps1
+++ b/07_ops/qps_roundtrip/Publish-QpsRelease.ps1
@@ -24,6 +24,17 @@ function Get-RelativeHashMap {
     return $map
 }
 
+function Copy-DirectoryContents {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    foreach ($item in Get-ChildItem -LiteralPath $Source -Force) {
+        Copy-Item -LiteralPath $item.FullName -Destination $Destination -Recurse -Force
+    }
+}
+
 if ([string]::IsNullOrWhiteSpace($ReleaseRoot)) {
     throw 'QPS_RELEASE_ROOT is not set and -ReleaseRoot was not provided.'
 }
@@ -45,7 +56,7 @@ if (Test-Path -LiteralPath $destination) {
 
 if ($PSCmdlet.ShouldProcess($destination, 'Publish immutable QPS release')) {
     New-Item -ItemType Directory -Path $destination -Force | Out-Null
-    Copy-Item -LiteralPath (Join-Path $SourceDist '*') -Destination $destination -Recurse -Force
+    Copy-DirectoryContents -Source $SourceDist -Destination $destination
 
     $sourceHashes = Get-RelativeHashMap -Root $SourceDist
     $destinationHashes = Get-RelativeHashMap -Root $destination
@@ -92,7 +103,7 @@ if ($PSCmdlet.ShouldProcess($destination, 'Publish immutable QPS release')) {
             throw "Office review destination already exists: $reviewDestination"
         }
         New-Item -ItemType Directory -Path $reviewDestination -Force | Out-Null
-        Copy-Item -LiteralPath (Join-Path $destination '*') -Destination $reviewDestination -Recurse -Force
+        Copy-DirectoryContents -Source $destination -Destination $reviewDestination
     }
 
     [ordered]@{

--- a/07_ops/qps_roundtrip/Publish-QpsRelease.ps1
+++ b/07_ops/qps_roundtrip/Publish-QpsRelease.ps1
@@ -1,0 +1,106 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [Parameter(Mandatory = $true)][string]$SourceDist,
+    [Parameter(Mandatory = $true)][string]$ReleaseId,
+    [string]$ReleaseRoot = $env:QPS_RELEASE_ROOT,
+    [switch]$CreateOfficeReviewCopy
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-RelativeHashMap {
+    param([Parameter(Mandatory = $true)][string]$Root)
+
+    $resolved = (Resolve-Path -LiteralPath $Root).Path
+    $map = [ordered]@{}
+    foreach ($file in Get-ChildItem -LiteralPath $resolved -File -Recurse | Sort-Object FullName) {
+        $relative = [System.IO.Path]::GetRelativePath($resolved, $file.FullName).Replace('\', '/')
+        if ($relative -eq 'MANIFEST.sha256') {
+            continue
+        }
+        $map[$relative] = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+    return $map
+}
+
+if ([string]::IsNullOrWhiteSpace($ReleaseRoot)) {
+    throw 'QPS_RELEASE_ROOT is not set and -ReleaseRoot was not provided.'
+}
+if (-not (Test-Path -LiteralPath $SourceDist)) {
+    throw "Source distribution does not exist: $SourceDist"
+}
+
+$required = @('BUILD_META.json', 'RELEASE_NOTES.md', 'QA_REPORT.md')
+foreach ($name in $required) {
+    if (-not (Test-Path -LiteralPath (Join-Path $SourceDist $name))) {
+        throw "Required release file is missing: $name"
+    }
+}
+
+$destination = Join-Path $ReleaseRoot $ReleaseId
+if (Test-Path -LiteralPath $destination) {
+    throw "Immutable release destination already exists: $destination"
+}
+
+if ($PSCmdlet.ShouldProcess($destination, 'Publish immutable QPS release')) {
+    New-Item -ItemType Directory -Path $destination -Force | Out-Null
+    Copy-Item -LiteralPath (Join-Path $SourceDist '*') -Destination $destination -Recurse -Force
+
+    $sourceHashes = Get-RelativeHashMap -Root $SourceDist
+    $destinationHashes = Get-RelativeHashMap -Root $destination
+
+    $differences = @()
+    foreach ($key in $sourceHashes.Keys) {
+        if (-not $destinationHashes.Contains($key)) {
+            $differences += "Missing at destination: $key"
+            continue
+        }
+        if ($sourceHashes[$key] -ne $destinationHashes[$key]) {
+            $differences += "Hash mismatch: $key"
+        }
+    }
+    foreach ($key in $destinationHashes.Keys) {
+        if (-not $sourceHashes.Contains($key)) {
+            $differences += "Unexpected at destination: $key"
+        }
+    }
+
+    if ($differences.Count -gt 0) {
+        throw ("Release verification failed:`n" + ($differences -join "`n"))
+    }
+
+    $manifestLines = @(
+        '# QPS release SHA-256 manifest'
+        "# release_id=$ReleaseId"
+        "# generated_utc=$([DateTime]::UtcNow.ToString('o'))"
+    )
+    $manifestLines += $destinationHashes.GetEnumerator() |
+        ForEach-Object { '{0}  {1}' -f $_.Value, $_.Key }
+    [System.IO.File]::WriteAllLines(
+        (Join-Path $destination 'MANIFEST.sha256'),
+        $manifestLines,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+
+    $reviewDestination = $null
+    if ($CreateOfficeReviewCopy) {
+        $costRoot = Split-Path -Parent $ReleaseRoot
+        $reviewRoot = Join-Path $costRoot '20_WORKING_REVIEW'
+        $reviewDestination = Join-Path $reviewRoot $ReleaseId
+        if (Test-Path -LiteralPath $reviewDestination) {
+            throw "Office review destination already exists: $reviewDestination"
+        }
+        New-Item -ItemType Directory -Path $reviewDestination -Force | Out-Null
+        Copy-Item -LiteralPath (Join-Path $destination '*') -Destination $reviewDestination -Recurse -Force
+    }
+
+    [ordered]@{
+        release_id = $ReleaseId
+        source = (Resolve-Path -LiteralPath $SourceDist).Path
+        destination = $destination
+        office_review_copy = $reviewDestination
+        verified_file_count = $sourceHashes.Count
+        result = 'PASS'
+    } | ConvertTo-Json -Depth 4
+}

--- a/07_ops/qps_roundtrip/README.md
+++ b/07_ops/qps_roundtrip/README.md
@@ -1,0 +1,38 @@
+# QPS Roundtrip Governance Tooling
+
+Control ID: GOV-001
+Repository role: reusable federation, CI, release, hash and local-workspace tooling.
+
+This directory is deliberately generic. It must not contain QPS bidder values, confidential evidence text or generated deliverables.
+
+## Tools
+
+- `Initialize-QpsWorkspace.ps1`: creates clean local repository, workspace and release roots outside OneDrive.
+- `Test-QpsTextOnlyPolicy.ps1`: blocks forbidden binary artifacts in the controlled source path.
+- `Get-QpsRecursiveManifest.ps1`: generates recursive SHA-256 manifests for evidence or release trees.
+- `Publish-QpsRelease.ps1`: copies a completed local release to a versioned OneDrive folder and verifies destination hashes.
+
+## Required environment variables
+
+```powershell
+$env:QPS_EVIDENCE_ROOT = '<OneDriveRoot>\QPS\Cost Estimate\00_EVIDENCE'
+$env:QPS_RELEASE_ROOT  = '<OneDriveRoot>\QPS\Cost Estimate\10_RELEASES'
+```
+
+Do not hardcode a user profile or OneDrive tenant name in repository source.
+
+## Intended sequence
+
+```text
+Initialize workspace
+  -> clone/fetch repositories
+  -> verify evidence registry
+  -> build outside Git working trees
+  -> generate QA and manifests
+  -> publish immutable release
+  -> create separate Office review copy
+```
+
+## Scope boundary
+
+`CODEX` provides the reusable governance layer only. Canonical QPS analytics remain in `GBOGEB/ABACUS`; project-specific confidential text remains in the private overlay.

--- a/07_ops/qps_roundtrip/RELEASE_NOTES.template.md
+++ b/07_ops/qps_roundtrip/RELEASE_NOTES.template.md
@@ -1,0 +1,50 @@
+# QPS Cost Estimate Release Notes
+
+Release ID: `<version>_<short-commit>_<build-id>`  
+Control ID: `GOV-001`  
+Generated UTC: `<timestamp>`
+
+## Source state
+
+- ABACUS commit: `<sha>`
+- CODEX commit: `<sha>`
+- Private overlay commit: `<sha>`
+- Evidence registry hash: `<sha256>`
+- Source-tree semantic hash: `<sha256>`
+
+## Evidence state
+
+List each required evidence ID, expected filename, verified SHA-256, size and classification. Do not embed confidential evidence content here.
+
+## Main model changes
+
+- `<change>`
+
+## QA gates
+
+- [ ] Evidence hash verification
+- [ ] SSOT/schema validation
+- [ ] Workbook formula validation
+- [ ] Workbook visual/render validation
+- [ ] DOCX render validation
+- [ ] PPTX render validation
+- [ ] PDF render validation
+- [ ] HTML asset/navigation validation
+- [ ] Semantic manifest generated
+- [ ] Exact artifact manifest generated
+- [ ] Clean verification-clone comparison
+
+## Published artifacts
+
+List artifact filename, semantic hash where applicable, exact artifact SHA-256 and size.
+
+## Known limitations / open actions
+
+- `<item>`
+
+## Office review
+
+Immutable release folder: `<path or release ID>`  
+Working review copy: `<path or review ID>`
+
+Office edits must be registered in the private overlay review-change register and assimilated into source before a new release is produced.

--- a/07_ops/qps_roundtrip/Start-QpsWave2.ps1
+++ b/07_ops/qps_roundtrip/Start-QpsWave2.ps1
@@ -1,0 +1,115 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$RepoRoot = 'C:\DEV\REPOS',
+    [string]$WorkspaceRoot = 'C:\DEV\WORKSPACES\qps-cost',
+    [Parameter(Mandatory = $true)][string]$EvidenceRoot,
+    [Parameter(Mandatory = $true)][string]$ReleaseRoot,
+    [switch]$SkipClone,
+    [switch]$CreateOneDriveFolders
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositories = @(
+    [pscustomobject]@{ Name = 'ABACUS'; Url = 'https://github.com/GBOGEB/ABACUS.git' },
+    [pscustomobject]@{ Name = 'CODEX'; Url = 'https://github.com/GBOGEB/CODEX.git' },
+    [pscustomobject]@{ Name = 'cryoplant-project'; Url = 'https://github.com/GBOGEB/cryoplant-project.git' },
+    [pscustomobject]@{ Name = 'DOCX_RTM_Automation'; Url = 'https://github.com/GBOGEB/DOCX_RTM_Automation.git' }
+)
+
+function Assert-Command {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command is not available: $Name"
+    }
+}
+
+function Assert-CleanRepository {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $status = @(git -C $Path status --porcelain)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to read Git status: $Path"
+    }
+    if ($status.Count -gt 0) {
+        throw "Repository has local changes and will not be updated automatically: $Path"
+    }
+}
+
+Assert-Command -Name 'git'
+
+if (-not (Test-Path -LiteralPath $RepoRoot)) {
+    if ($PSCmdlet.ShouldProcess($RepoRoot, 'Create repository root')) {
+        New-Item -ItemType Directory -Path $RepoRoot -Force | Out-Null
+    }
+}
+
+if (-not $SkipClone) {
+    foreach ($repo in $repositories) {
+        $path = Join-Path $RepoRoot $repo.Name
+        if (-not (Test-Path -LiteralPath $path)) {
+            if ($PSCmdlet.ShouldProcess($path, "Clone $($repo.Url)")) {
+                git clone $repo.Url $path
+                if ($LASTEXITCODE -ne 0) { throw "Clone failed: $($repo.Name)" }
+            }
+        } else {
+            if (-not (Test-Path -LiteralPath (Join-Path $path '.git'))) {
+                throw "Existing path is not a Git clone: $path"
+            }
+            Assert-CleanRepository -Path $path
+            if ($PSCmdlet.ShouldProcess($path, 'Fetch and fast-forward default branch')) {
+                git -C $path fetch --all --prune
+                if ($LASTEXITCODE -ne 0) { throw "Fetch failed: $($repo.Name)" }
+                $defaultBranch = (git -C $path symbolic-ref refs/remotes/origin/HEAD).Trim() -replace '^refs/remotes/origin/', ''
+                if ([string]::IsNullOrWhiteSpace($defaultBranch)) { throw "Unable to determine default branch: $($repo.Name)" }
+                git -C $path switch $defaultBranch
+                if ($LASTEXITCODE -ne 0) { throw "Switch failed: $($repo.Name)" }
+                git -C $path pull --ff-only
+                if ($LASTEXITCODE -ne 0) { throw "Fast-forward pull failed: $($repo.Name)" }
+            }
+        }
+    }
+}
+
+$env:QPS_EVIDENCE_ROOT = $EvidenceRoot
+$env:QPS_RELEASE_ROOT = $ReleaseRoot
+
+$initializer = Join-Path $RepoRoot 'CODEX\07_ops\qps_roundtrip\Initialize-QpsWorkspace.ps1'
+if (-not (Test-Path -LiteralPath $initializer)) {
+    throw "QPS workspace initializer not found. Ensure the CODEX Wave 1 tooling is merged/present: $initializer"
+}
+
+$initArgs = @{
+    RepoRoot = $RepoRoot
+    WorkspaceRoot = $WorkspaceRoot
+    EvidenceRoot = $EvidenceRoot
+    ReleaseRoot = $ReleaseRoot
+}
+if ($CreateOneDriveFolders) { $initArgs.CreateOneDriveFolders = $true }
+
+& $initializer @initArgs | Write-Host
+
+$repoState = foreach ($repo in $repositories) {
+    $path = Join-Path $RepoRoot $repo.Name
+    if (Test-Path -LiteralPath (Join-Path $path '.git')) {
+        [pscustomobject]@{
+            repository = $repo.Name
+            path = $path
+            branch = (git -C $path branch --show-current).Trim()
+            commit = (git -C $path rev-parse HEAD).Trim()
+            clean = (@(git -C $path status --porcelain).Count -eq 0)
+        }
+    }
+}
+
+[ordered]@{
+    phase = 'W002-bootstrap'
+    repo_root = $RepoRoot
+    workspace_root = $WorkspaceRoot
+    evidence_root = $EvidenceRoot
+    release_root = $ReleaseRoot
+    repositories = @($repoState)
+    timestamp_utc = [DateTime]::UtcNow.ToString('o')
+    result = 'READY_FOR_EVIDENCE_BINDING'
+} | ConvertTo-Json -Depth 5

--- a/07_ops/qps_roundtrip/Test-QpsTextOnlyPolicy.ps1
+++ b/07_ops/qps_roundtrip/Test-QpsTextOnlyPolicy.ps1
@@ -1,0 +1,67 @@
+[CmdletBinding()]
+param(
+    [string]$RepositoryPath = '.',
+    [string[]]$ControlledPaths = @(
+        'analytics/qps_cost_estimate_roundtrip/',
+        '07_ops/qps_roundtrip/',
+        'qps_cost_overlay/'
+    ),
+    [string[]]$FileList,
+    [switch]$IncludeUntracked
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$forbiddenPattern = '\.(xlsx|xlsm|xlsb|docx|pptx|pdf|png|jpg|jpeg|gif|zip|tar|gz|7z|rar)$'
+$temporaryPattern = '(^|/)(~\$|\.DS_Store$)|\.(tmp|bak|swp)$'
+
+Push-Location $RepositoryPath
+try {
+    if (-not $FileList) {
+        $FileList = @(git diff --cached --name-only --diff-filter=ACMR)
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Unable to read staged Git file list.'
+        }
+
+        if ($IncludeUntracked) {
+            $FileList += @(git ls-files --others --exclude-standard)
+            if ($LASTEXITCODE -ne 0) {
+                throw 'Unable to read untracked Git file list.'
+            }
+        }
+    }
+
+    $normalized = $FileList |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        ForEach-Object { $_.Replace('\', '/') } |
+        Sort-Object -Unique
+
+    $controlled = foreach ($file in $normalized) {
+        foreach ($prefix in $ControlledPaths) {
+            if ($file.StartsWith($prefix.Replace('\', '/'), [System.StringComparison]::OrdinalIgnoreCase)) {
+                $file
+                break
+            }
+        }
+    }
+
+    $blocked = @($controlled | Where-Object {
+        ($_ -match $forbiddenPattern) -or ($_ -match $temporaryPattern)
+    })
+
+    if ($blocked.Count -gt 0) {
+        Write-Error ("QPS text-only policy failed. Remove these files from Git:`n" + ($blocked -join "`n"))
+        exit 1
+    }
+
+    [ordered]@{
+        policy = 'QPS text-only controlled paths'
+        checked_files = @($controlled).Count
+        blocked_files = 0
+        result = 'PASS'
+    } | ConvertTo-Json -Depth 3
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## GOV-001 / Wave 1 reusable tooling

Adds generic, public-safe tooling for the QPS GitHub -> local clone -> OneDrive release roundtrip.

### Included

- workspace initializer for `C:\DEV\REPOS` and `C:\DEV\WORKSPACES\qps-cost`;
- scoped text-only policy guard;
- recursive SHA-256 manifest generator;
- immutable release publisher with destination hash verification;
- optional separate Office review copy;
- build metadata template;
- repository-role and confidentiality boundary documentation.

### Safety boundaries

- no QPS commercial values;
- no confidential evidence text;
- no generated Office/PDF/image/archive binaries;
- no hardcoded user or tenant paths;
- no changes to existing QPS analytics in ABACUS.

### Wave 1 gate

- [x] generic scripts added
- [x] build metadata contract added
- [ ] local Windows dry run
- [ ] link ABACUS architecture PR
- [ ] link private overlay PR
- [ ] review and merge

The scripts are designed to fail closed on existing immutable release folders and destination hash mismatches.