### PR TITLE
feat(qps-roundtrip): Phase 3–5 release validation and review ledger

### DIFF
--- a/07_ops/qps_roundtrip/New-QpsReviewChange.ps1
+++ b/07_ops/qps_roundtrip/New-QpsReviewChange.ps1
@@ -1,0 +1,59 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$LedgerPath,
+    [Parameter(Mandatory = $true)][string]$SourceReleaseId,
+    [Parameter(Mandatory = $true)][string]$ReviewFile,
+    [Parameter(Mandatory = $true)][string]$ReviewLocation,
+    [Parameter(Mandatory = $true)][string]$Reviewer,
+    [Parameter(Mandatory = $true)][ValidateSet('DATA','CALCULATION_LOGIC','NARRATIVE','FORMATTING')][string]$ChangeClass,
+    [Parameter(Mandatory = $true)][string]$Rationale,
+    [string]$RequestedChange = '',
+    [ValidateSet('OPEN','ACCEPTED','REJECTED','SUPERSEDED','IMPLEMENTED')][string]$Disposition = 'OPEN',
+    [string]$TargetReleaseId = '',
+    [string]$SourceCommit = '',
+    [string]$Approver = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$parent = Split-Path -Parent $LedgerPath
+if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+}
+
+$existing = @()
+if (Test-Path -LiteralPath $LedgerPath) {
+    $existing = @(Import-Csv -LiteralPath $LedgerPath)
+}
+
+$next = $existing.Count + 1
+$changeId = 'QPS-CHG-{0:D5}' -f $next
+$timestamp = [DateTime]::UtcNow.ToString('o')
+
+if ($Disposition -eq 'IMPLEMENTED' -and [string]::IsNullOrWhiteSpace($TargetReleaseId)) {
+    throw 'TargetReleaseId is required when Disposition is IMPLEMENTED.'
+}
+if ($Disposition -eq 'IMPLEMENTED' -and [string]::IsNullOrWhiteSpace($SourceCommit)) {
+    throw 'SourceCommit is required when Disposition is IMPLEMENTED.'
+}
+
+$record = [pscustomobject][ordered]@{
+    change_id = $changeId
+    source_release_id = $SourceReleaseId
+    review_file = $ReviewFile
+    review_location = $ReviewLocation
+    reviewer = $Reviewer
+    requested_utc = $timestamp
+    change_class = $ChangeClass
+    requested_change = $RequestedChange
+    rationale = $Rationale
+    disposition = $Disposition
+    target_release_id = $TargetReleaseId
+    source_commit = $SourceCommit
+    approver = $Approver
+}
+
+@($existing + $record) | Export-Csv -LiteralPath $LedgerPath -NoTypeInformation -Encoding utf8
+
+$record | ConvertTo-Json -Depth 3

--- a/07_ops/qps_roundtrip/Test-QpsReleaseBundle.ps1
+++ b/07_ops/qps_roundtrip/Test-QpsReleaseBundle.ps1
@@ -1,0 +1,113 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$DistPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $DistPath)) {
+    throw "Release bundle does not exist: $DistPath"
+}
+
+$required = @(
+    'QPS_COST_Master.xlsx',
+    'QPS_Cost_Engineering_Handover.docx',
+    'QPS_Cost_Management_Deck.pptx',
+    'QPS_Cost_Engineering_Handover.pdf',
+    'index.html',
+    'QA_REPORT.md',
+    'RELEASE_NOTES.md',
+    'BUILD_META.json',
+    'MANIFEST.sha256'
+)
+
+$missing = @()
+foreach ($name in $required) {
+    if (-not (Test-Path -LiteralPath (Join-Path $DistPath $name))) {
+        $missing += $name
+    }
+}
+if ($missing.Count -gt 0) {
+    throw ("Missing required release files:`n" + ($missing -join "`n"))
+}
+
+$metaPath = Join-Path $DistPath 'BUILD_META.json'
+try {
+    $meta = Get-Content -LiteralPath $metaPath -Raw | ConvertFrom-Json
+}
+catch {
+    throw "BUILD_META.json is not valid JSON: $($_.Exception.Message)"
+}
+
+$requiredMeta = @(
+    'schema_version',
+    'control_id',
+    'release_id',
+    'generated_utc',
+    'repositories',
+    'source_tree_sha256',
+    'evidence_registry_sha256',
+    'qa',
+    'publication'
+)
+$missingMeta = @()
+foreach ($field in $requiredMeta) {
+    if (-not ($meta.PSObject.Properties.Name -contains $field)) {
+        $missingMeta += $field
+    }
+}
+if ($missingMeta.Count -gt 0) {
+    throw ("BUILD_META.json missing fields:`n" + ($missingMeta -join "`n"))
+}
+
+if ($meta.qa.status -ne 'PASS') {
+    throw "QA status must be PASS before publication. Current: $($meta.qa.status)"
+}
+if (-not $meta.publication.immutable_release) {
+    throw 'BUILD_META publication.immutable_release must be true.'
+}
+if (-not $meta.publication.office_review_copy) {
+    throw 'BUILD_META publication.office_review_copy must be true.'
+}
+
+$manifestPath = Join-Path $DistPath 'MANIFEST.sha256'
+$manifestLines = Get-Content -LiteralPath $manifestPath |
+    Where-Object { $_ -and -not $_.StartsWith('#') }
+if ($manifestLines.Count -eq 0) {
+    throw 'MANIFEST.sha256 contains no artifact records.'
+}
+
+$manifestMap = @{}
+foreach ($line in $manifestLines) {
+    if ($line -notmatch '^([0-9a-fA-F]{64})\s\s(.+)$') {
+        throw "Invalid manifest line: $line"
+    }
+    $manifestMap[$Matches[2].Replace('\','/')] = $Matches[1].ToLowerInvariant()
+}
+
+$mismatches = @()
+foreach ($entry in $manifestMap.GetEnumerator()) {
+    $path = Join-Path $DistPath $entry.Key
+    if (-not (Test-Path -LiteralPath $path)) {
+        $mismatches += "Missing file referenced by manifest: $($entry.Key)"
+        continue
+    }
+    $actual = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $entry.Value) {
+        $mismatches += "Hash mismatch: $($entry.Key)"
+    }
+}
+if ($mismatches.Count -gt 0) {
+    throw ("Release manifest verification failed:`n" + ($mismatches -join "`n"))
+}
+
+[ordered]@{
+    result = 'PASS'
+    release_id = $meta.release_id
+    required_files = $required.Count
+    manifest_records = $manifestMap.Count
+    qa_status = $meta.qa.status
+    immutable_release = [bool]$meta.publication.immutable_release
+    office_review_copy = [bool]$meta.publication.office_review_copy
+} | ConvertTo-Json -Depth 4


### PR DESCRIPTION
## GOV-001 / Phases 3–5 runtime hardening

Adds executable runtime controls corresponding to the ABACUS Phase 3–5 schemas.

### `Test-QpsReleaseBundle.ps1`
- requires the complete XLSX/DOCX/PPTX/PDF/HTML release set;
- validates `BUILD_META.json` structure and QA status;
- requires immutable-release + Office-review-copy flags;
- validates every `MANIFEST.sha256` entry against the actual local bundle;
- fails closed before publication.

### `New-QpsReviewChange.ps1`
- records Office review requests in a normalized CSV ledger;
- enforces DATA / CALCULATION_LOGIC / NARRATIVE / FORMATTING classes;
- generates sequential QPS change IDs;
- requires target release + source commit before a change may be marked IMPLEMENTED;
- records the binary file/location as review provenance without making the binary a Git source.

### Boundary

This does not publish to OneDrive and does not claim Phase 4 completion. It makes the later local review/publication steps machine-checkable.

No QPS commercial values or generated binaries are included.