### PR TITLE
feat(qps-roundtrip): semantic manifest and legacy binary audit

### DIFF
--- a/.github/workflows/qps-roundtrip-policy.yml
+++ b/.github/workflows/qps-roundtrip-policy.yml
@@ -49,10 +49,38 @@ jobs:
           }
           if ($failed) { exit 1 }
 
+      - name: Compile Python semantic extractor
+        shell: pwsh
+        run: python -m py_compile ./07_ops/qps_roundtrip/Get-QpsSemanticManifest.py
+
       - name: Validate BUILD_META template JSON
         shell: pwsh
         run: |
           Get-Content ./07_ops/qps_roundtrip/BUILD_META.template.json -Raw | ConvertFrom-Json | Out-Null
+
+      - name: Synthetic semantic manifest smoke test
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:RUNNER_TEMP 'qps-semantic-smoke'
+          New-Item -ItemType Directory -Force $root | Out-Null
+          $html = Join-Path $root 'index.html'
+          Set-Content -LiteralPath $html -Encoding utf8 -Value '<!doctype html><html><body><section id="summary"><h1>QPS Summary</h1><a href="local.css">style</a><script type="application/json">{"value":1}</script></section></body></html>'
+          $out = Join-Path $root 'semantic.json'
+          python ./07_ops/qps_roundtrip/Get-QpsSemanticManifest.py $html -o $out
+          $manifest = Get-Content $out -Raw | ConvertFrom-Json
+          if ($manifest.kind -ne 'html') { throw 'Unexpected semantic kind.' }
+          if ($manifest.heading_sequence[0] -ne 'QPS Summary') { throw 'Heading extraction failed.' }
+          if (-not $manifest.semantic_sha256) { throw 'Semantic SHA-256 missing.' }
+
+      - name: Tracked binary inventory smoke test
+        shell: pwsh
+        run: |
+          $out = Join-Path $env:RUNNER_TEMP 'qps-binary-inventory.json'
+          $result = & ./07_ops/qps_roundtrip/Get-QpsLegacyBinaryInventory.ps1 -RepositoryPath . -OutputPath $out | ConvertFrom-Json
+          if (-not (Test-Path $out)) { throw 'Binary inventory was not created.' }
+          if ($result.policy_violations -ne 0) { throw 'Controlled QPS path contains tracked binaries.' }
+          Write-Host "Tracked legacy binaries: $($result.tracked_binary_count)"
+          Write-Host "Regenerate/migrate candidates: $($result.regenerate_or_migrate)"
 
       - name: Synthetic manifest smoke test
         shell: pwsh

--- a/07_ops/qps_roundtrip/Get-QpsLegacyBinaryInventory.ps1
+++ b/07_ops/qps_roundtrip/Get-QpsLegacyBinaryInventory.ps1
@@ -1,0 +1,64 @@
+[CmdletBinding()]
+param(
+    [string]$RepositoryPath = '.',
+    [string]$OutputPath,
+    [string[]]$Extensions = @(
+        '.xlsx','.xlsm','.xlsb','.docx','.pptx','.pdf',
+        '.png','.jpg','.jpeg','.gif','.zip','.tar','.gz','.7z','.rar'
+    )
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Push-Location $RepositoryPath
+try {
+    $root = (Get-Location).Path
+    $tracked = @(git ls-files)
+    if ($LASTEXITCODE -ne 0) { throw 'git ls-files failed.' }
+
+    $records = foreach ($relative in $tracked) {
+        $ext = [System.IO.Path]::GetExtension($relative).ToLowerInvariant()
+        if ($Extensions -notcontains $ext) { continue }
+
+        $full = Join-Path $root $relative
+        $size = if (Test-Path -LiteralPath $full) { (Get-Item -LiteralPath $full).Length } else { $null }
+        $classification = if ($relative -like '07_ops/qps_roundtrip/*') {
+            'POLICY_VIOLATION'
+        } elseif ($relative -match '(^|/)(build|dist|output|outputs|render|preview|generated)(/|$)' -or $ext -in @('.png','.jpg','.jpeg','.gif')) {
+            'REGENERATE_OR_MIGRATE'
+        } else {
+            'REVIEW_KEEP_OR_MIGRATE'
+        }
+
+        [pscustomobject]@{
+            path = $relative.Replace('\','/')
+            extension = $ext
+            size_bytes = $size
+            classification = $classification
+            history_rewrite_required_to_purge = $true
+        }
+    }
+
+    $records = @($records | Sort-Object path)
+    if ($OutputPath) {
+        $parent = Split-Path -Parent $OutputPath
+        if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+            New-Item -ItemType Directory -Path $parent -Force | Out-Null
+        }
+        $records | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $OutputPath -Encoding utf8
+    }
+
+    [ordered]@{
+        repository = $root
+        tracked_binary_count = $records.Count
+        policy_violations = @($records | Where-Object classification -eq 'POLICY_VIOLATION').Count
+        regenerate_or_migrate = @($records | Where-Object classification -eq 'REGENERATE_OR_MIGRATE').Count
+        review_keep_or_migrate = @($records | Where-Object classification -eq 'REVIEW_KEEP_OR_MIGRATE').Count
+        output = $OutputPath
+        result = if (@($records | Where-Object classification -eq 'POLICY_VIOLATION').Count -eq 0) { 'PASS' } else { 'FAIL' }
+    } | ConvertTo-Json -Depth 4
+}
+finally {
+    Pop-Location
+}

--- a/07_ops/qps_roundtrip/Get-QpsSemanticManifest.py
+++ b/07_ops/qps_roundtrip/Get-QpsSemanticManifest.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Generate a deterministic semantic manifest for QPS release artifacts.
+
+The extractor intentionally separates semantic comparison from exact binary hashes.
+It uses only the Python standard library and supports XLSX, DOCX, PPTX and HTML.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import unicodedata
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+NS = {
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+    "c": "http://schemas.openxmlformats.org/drawingml/2006/chart",
+    "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
+    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+    "s": "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+    "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+}
+
+
+def norm_text(value: str) -> str:
+    value = unicodedata.normalize("NFC", value or "")
+    value = value.replace("\r\n", "\n").replace("\r", "\n")
+    return re.sub(r"[ \t]+", " ", value).strip()
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(norm_text(value).encode("utf-8")).hexdigest()
+
+
+def xml_root(zf: zipfile.ZipFile, name: str):
+    try:
+        return ET.fromstring(zf.read(name))
+    except KeyError:
+        return None
+
+
+def relmap(zf: zipfile.ZipFile, name: str) -> dict[str, str]:
+    root = xml_root(zf, name)
+    if root is None:
+        return {}
+    return {
+        el.attrib.get("Id", ""): el.attrib.get("Target", "")
+        for el in root
+        if el.attrib.get("Id")
+    }
+
+
+def xlsx_manifest(path: Path) -> dict:
+    with zipfile.ZipFile(path) as zf:
+        wb = xml_root(zf, "xl/workbook.xml")
+        rels = relmap(zf, "xl/_rels/workbook.xml.rels")
+        sheets = []
+        defined = []
+        formulas = {}
+        controlled_values = {}
+        tables = []
+        chart_sources = []
+        if wb is not None:
+            for sh in wb.findall("s:sheets/s:sheet", NS):
+                rid = sh.attrib.get(f"{{{NS['r']}}}id", "")
+                target = rels.get(rid, "")
+                if target and not target.startswith("xl/"):
+                    target = "xl/" + target.lstrip("/")
+                sheets.append({"name": sh.attrib.get("name", ""), "target": target})
+            for dn in wb.findall("s:definedNames/s:definedName", NS):
+                defined.append({"name": dn.attrib.get("name", ""), "value": norm_text(dn.text or "")})
+        for sh in sheets:
+            root = xml_root(zf, sh["target"])
+            if root is None:
+                continue
+            for cell in root.findall(".//s:c", NS):
+                ref = cell.attrib.get("r", "")
+                f = cell.find("s:f", NS)
+                v = cell.find("s:v", NS)
+                key = f"{sh['name']}!{ref}"
+                if f is not None:
+                    formulas[key] = norm_text(f.text or "")
+                elif v is not None:
+                    controlled_values[key] = norm_text(v.text or "")
+        for name in sorted(n for n in zf.namelist() if n.startswith("xl/tables/") and n.endswith(".xml")):
+            root = xml_root(zf, name)
+            if root is not None:
+                tables.append({"name": root.attrib.get("name", ""), "ref": root.attrib.get("ref", "")})
+        formula_tags = {f"{{{NS['c']}}}f"}
+        for name in sorted(n for n in zf.namelist() if n.startswith("xl/charts/") and n.endswith(".xml")):
+            root = xml_root(zf, name)
+            if root is not None:
+                refs = sorted({norm_text(el.text or "") for el in root.iter() if el.tag in formula_tags and norm_text(el.text or "")})
+                chart_sources.append({"chart": name, "sources": refs})
+        return {
+            "kind": "xlsx",
+            "sheet_order": [s["name"] for s in sheets],
+            "sheet_names": sorted(s["name"] for s in sheets),
+            "defined_names": sorted(defined, key=lambda x: (x["name"], x["value"])),
+            "normalized_formula_map": dict(sorted(formulas.items())),
+            "normalized_value_map_for_controlled_cells": dict(sorted(controlled_values.items())),
+            "table_names_and_ranges": sorted(tables, key=lambda x: (x["name"], x["ref"])),
+            "chart_data_source_ranges": chart_sources,
+        }
+
+
+def docx_manifest(path: Path) -> dict:
+    with zipfile.ZipFile(path) as zf:
+        root = xml_root(zf, "word/document.xml")
+        headings, paragraphs, tables, links = [], [], [], []
+        if root is not None:
+            for p in root.findall(".//w:p", NS):
+                text = norm_text("".join(t.text or "" for t in p.findall(".//w:t", NS)))
+                if not text:
+                    continue
+                paragraphs.append(sha256_text(text))
+                style = p.find("w:pPr/w:pStyle", NS)
+                sval = style.attrib.get(f"{{{NS['w']}}}val", "") if style is not None else ""
+                if sval.lower().startswith("heading"):
+                    headings.append(text)
+                for h in p.findall(".//w:hyperlink", NS):
+                    anchor = h.attrib.get(f"{{{NS['w']}}}anchor")
+                    if anchor:
+                        links.append(anchor)
+            for tbl in root.findall(".//w:tbl", NS):
+                rows = tbl.findall("w:tr", NS)
+                row_text = []
+                max_cols = 0
+                for row in rows:
+                    cells = row.findall("w:tc", NS)
+                    max_cols = max(max_cols, len(cells))
+                    row_text.append(" | ".join(norm_text("".join(t.text or "" for t in c.findall(".//w:t", NS))) for c in cells))
+                tables.append({"rows": len(rows), "cols_max": max_cols, "text_hash": sha256_text("\n".join(row_text))})
+        return {
+            "kind": "docx",
+            "heading_sequence": headings,
+            "paragraph_text_hashes": paragraphs,
+            "table_shape_and_text_hashes": tables,
+            "internal_link_targets": sorted(set(links)),
+        }
+
+
+def pptx_manifest(path: Path) -> dict:
+    with zipfile.ZipFile(path) as zf:
+        pres = xml_root(zf, "ppt/presentation.xml")
+        rels = relmap(zf, "ppt/_rels/presentation.xml.rels")
+        slide_paths = []
+        if pres is not None:
+            for sid in pres.findall("p:sldIdLst/p:sldId", NS):
+                rid = sid.attrib.get(f"{{{NS['r']}}}id", "")
+                target = rels.get(rid, "")
+                if target and not target.startswith("ppt/"):
+                    target = "ppt/" + target.lstrip("/")
+                slide_paths.append(target)
+        titles, text_hashes, counts, notes_hashes = [], [], [], []
+        for spath in slide_paths:
+            root = xml_root(zf, spath)
+            texts = []
+            if root is not None:
+                texts = [norm_text(t.text or "") for t in root.findall(".//a:t", NS) if norm_text(t.text or "")]
+                counts.append(sum(1 for _ in root.iter()))
+            else:
+                counts.append(0)
+            titles.append(texts[0] if texts else "")
+            text_hashes.append(sha256_text("\n".join(texts)))
+            m = re.search(r"slide(\d+)\.xml$", spath)
+            note_text = ""
+            if m:
+                nroot = xml_root(zf, f"ppt/notesSlides/notesSlide{m.group(1)}.xml")
+                if nroot is not None:
+                    note_text = "\n".join(norm_text(t.text or "") for t in nroot.findall(".//a:t", NS) if norm_text(t.text or ""))
+            notes_hashes.append(sha256_text(note_text))
+        chart_hashes = []
+        for name in sorted(n for n in zf.namelist() if n.startswith("ppt/charts/") and n.endswith(".xml")):
+            root = xml_root(zf, name)
+            refs = [] if root is None else sorted({norm_text(el.text or "") for el in root.findall(".//c:f", NS) if norm_text(el.text or "")})
+            chart_hashes.append({"chart": name, "source_hash": sha256_text("\n".join(refs))})
+        return {
+            "kind": "pptx",
+            "slide_order": slide_paths,
+            "slide_titles": titles,
+            "normalized_text_hashes": text_hashes,
+            "object_count_by_slide": counts,
+            "chart_data_hashes": chart_hashes,
+            "notes_text_hashes": notes_hashes,
+        }
+
+
+def html_manifest(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    ids = re.findall(r"\bid=[\"']([^\"']+)[\"']", text, flags=re.I)
+    headings = [norm_text(re.sub(r"<[^>]+>", "", x)) for x in re.findall(r"<h[1-6][^>]*>(.*?)</h[1-6]>", text, flags=re.I | re.S)]
+    assets = sorted(set(re.findall(r"(?:src|href)=[\"']([^\"']+)[\"']", text, flags=re.I)))
+    visible = norm_text(re.sub(r"<script\b.*?</script>|<style\b.*?</style>|<[^>]+>", " ", text, flags=re.I | re.S))
+    embedded = [sha256_text(x) for x in re.findall(r"<script[^>]+type=[\"']application/(?:json|ld\+json)[\"'][^>]*>(.*?)</script>", text, flags=re.I | re.S)]
+    return {
+        "kind": "html",
+        "route_or_section_ids": ids,
+        "heading_sequence": headings,
+        "local_asset_paths": assets,
+        "normalized_text_hashes": [sha256_text(visible)],
+        "embedded_data_hashes": embedded,
+    }
+
+
+def build(path: Path) -> dict:
+    ext = path.suffix.lower()
+    handlers = {".xlsx": xlsx_manifest, ".docx": docx_manifest, ".pptx": pptx_manifest, ".html": html_manifest, ".htm": html_manifest}
+    if ext not in handlers:
+        raise SystemExit(f"Unsupported artifact type: {ext}")
+    result = handlers[ext](path)
+    result["artifact_name"] = path.name
+    canonical = json.dumps(result, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    result["semantic_sha256"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return result
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("artifact", type=Path)
+    ap.add_argument("-o", "--output", type=Path)
+    args = ap.parse_args()
+    result = build(args.artifact)
+    payload = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(payload, encoding="utf-8", newline="\n")
+    else:
+        print(payload, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/07_ops/qps_roundtrip/README.md
+++ b/07_ops/qps_roundtrip/README.md
@@ -8,9 +8,14 @@ This directory is deliberately generic. It must not contain QPS bidder values, c
 ## Tools
 
 - `Initialize-QpsWorkspace.ps1`: creates clean local repository, workspace and release roots outside OneDrive.
+- `Start-QpsWave2.ps1`: Windows entry point for clean-clone Phase-2 execution.
 - `Test-QpsTextOnlyPolicy.ps1`: blocks forbidden binary artifacts in the controlled source path.
 - `Get-QpsRecursiveManifest.ps1`: generates recursive SHA-256 manifests for evidence or release trees.
+- `Get-QpsSemanticManifest.py`: extracts deterministic meaning-bearing structure from XLSX, DOCX, PPTX and HTML for clean-clone semantic comparison.
+- `Get-QpsLegacyBinaryInventory.ps1`: inventories tracked Office/PDF/image/archive binaries without deleting them or rewriting Git history.
+- `Test-QpsReleaseBundle.ps1`: validates a release bundle, BUILD_META state and manifest identity before publication.
 - `Publish-QpsRelease.ps1`: copies a completed local release to a versioned OneDrive folder and verifies destination hashes.
+- `New-QpsReviewChange.ps1`: records normalized Office review changes without treating edited binaries as Git source.
 
 ## Required environment variables
 
@@ -28,10 +33,24 @@ Initialize workspace
   -> clone/fetch repositories
   -> verify evidence registry
   -> build outside Git working trees
-  -> generate QA and manifests
+  -> generate QA + semantic + exact artifact manifests
+  -> compare clean-clone semantic manifests
+  -> validate release bundle
   -> publish immutable release
   -> create separate Office review copy
+  -> register review changes
+  -> assimilate approved changes into text source
 ```
+
+## Hash separation
+
+Use distinct controls for distinct claims:
+
+1. source/evidence SHA-256 proves which source material was used;
+2. semantic SHA-256 compares normalized meaning-bearing output structure across clean builds;
+3. artifact SHA-256 protects the exact published binary bytes.
+
+Semantic comparison does not replace formula evaluation, rendering QA or exact release hashes.
 
 ## Scope boundary
 


### PR DESCRIPTION
## PR CLASSIFICATION
- PR-ID: PR-244
- WAVE: W005
- SPRINT: S5-P1
- DOMAIN: EXECUTION_GOVERNANCE_INFRASTRUCTURE
- TYPE: CI_CD
- CRITICALITY: MEDIUM
- TOPOLOGY IMPACT: NO
- SCHEMA MUTATION: NO

---

## GOV-001 / Phase 5 hardening

Adds the next executable hardening layer after ABACUS #641 and CODEX #242 merged.

### Semantic manifest extractor

`Get-QpsSemanticManifest.py` generates deterministic JSON from meaning-bearing structure for:

- XLSX: sheet order/names, defined names, formulas, cached non-formula values, tables and chart source ranges;
- DOCX: heading sequence, paragraph text hashes, table shape/text hashes and internal link targets;
- PPTX: slide order/titles, normalized text hashes, slide object counts, chart source hashes and notes hashes;
- HTML: section IDs, heading sequence, asset paths, normalized visible text and embedded JSON hashes.

The semantic SHA-256 is intentionally separate from the raw artifact SHA-256. This follows the ABACUS semantic-manifest contract and does not treat volatile OOXML ZIP metadata as engineering meaning.

### Legacy binary inventory

`Get-QpsLegacyBinaryInventory.ps1` inventories tracked Office/PDF/image/archive binaries and classifies them as:

- `POLICY_VIOLATION` inside the controlled QPS roundtrip path;
- `REGENERATE_OR_MIGRATE` for obvious generated/output/preview/image paths;
- `REVIEW_KEEP_OR_MIGRATE` where human review is required.

It does not delete files or rewrite Git history.

### CI

The QPS policy workflow now:

- compiles the Python extractor;
- executes a synthetic HTML semantic-manifest test;
- generates a tracked-binary inventory and fails if the controlled QPS path contains binaries;
- retains existing text-only, recursive-manifest and immutable-publication smoke tests.

### Boundary

This PR advances Phase 5 only. The real QPS XLSX/DOCX/PPTX semantic comparison remains a Phase-2 local build gate because those release binaries are intentionally outside GitHub.